### PR TITLE
Buffer size roundtrip test

### DIFF
--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -90,13 +90,14 @@ struct CompositeWorker : Nan::AsyncWorker
         {
             vtzero::tile_builder builder;
             std::unordered_map<std::string, std::unique_ptr<vtzero::layer_builder>> builders;
-            std::clog << baton_data_->z << "z" << std::endl;
-            std::clog << baton_data_->x << "x" << std::endl;
-            std::clog << baton_data_->y << "y" << std::endl;
+            // std::clog << baton_data_->z << "z" << std::endl;
+            // std::clog << baton_data_->x << "x" << std::endl;
+            // std::clog << baton_data_->y << "y" << std::endl;
 
             for (auto const& tile_obj : baton_data_->tiles)
             {
-                std::cerr << tile_obj->z << ":" << tile_obj->x << ":" << tile_obj->y << std::endl;
+                // std::cerr << tile_obj->z << ":" << tile_obj->x << ":" << tile_obj->y << std::endl;
+                std::cout << "[buffer size] cpp pre vtzero: " << tile_obj->data.size() << std::endl;
                 vtzero::vector_tile tile{tile_obj->data};
                 while (auto layer = tile.next_layer())
                 {
@@ -123,7 +124,7 @@ struct CompositeWorker : Nan::AsyncWorker
                 }
             }
             builder.serialize(output_buffer_);
-            std::cerr << "VT Size:" << output_buffer_.size() << std::endl;
+            std::cerr << "[buffer size] cpp output:" << output_buffer_.size() << std::endl;
         }
         catch (std::exception const& e)
         {
@@ -144,7 +145,11 @@ struct CompositeWorker : Nan::AsyncWorker
         const auto argc = 2u;
         v8::Local<v8::Value> argv[argc] = {
             // this is where the vector tile buffer will go the "output_buffer_"
-            Nan::Null(), Nan::New<v8::String>(output_buffer_).ToLocalChecked()};
+            Nan::Null(),
+            Nan::NewBuffer(&output_buffer_[0], static_cast<std::uint32_t>(output_buffer_.size())).ToLocalChecked()
+        };
+
+
 
         // Static cast done here to avoid 'cppcoreguidelines-pro-bounds-array-to-pointer-decay' warning with clang-tidy
         callback->Call(argc, static_cast<v8::Local<v8::Value>*>(argv), async_resource);

--- a/test/vtcomposite.test.js
+++ b/test/vtcomposite.test.js
@@ -4,25 +4,17 @@ var fs = require('fs');
 var path = require('path');
 var bufferSF = fs.readFileSync(path.resolve(__dirname+'/../node_modules/@mapbox/mvt-fixtures/real-world/sanfrancisco/15-5238-12666.mvt'));
 
-test('[composite] composites successfully', function(t) {
-
-  const buffer = bufferSF;
-
-  var vtileSourceBuffers = [
-    {buffer: buffer, z:15, x:5238, y:12666}
+test('[composite] success: buffer size stays the same when no compositing needed', function(assert) {
+  const tiles = [
+    {buffer: bufferSF, z:15, x:5238, y:12666}
   ];
 
-  var zxy_ofmaprequest = {z:15, x:5238, y:12666};
+  const zxy = {z:15, x:5238, y:12666};
 
-  var options = {};
-
-  module.composite(vtileSourceBuffers, zxy_ofmaprequest, options, function(err, vtBuffer){
-    console.log('vtBuffer size:', vtBuffer.length);
-    //vtBuffer.features.forEach(function(feature) {
-    //  console.log('FEATURE', feature);
-    //});
-    t.end();
-    // t.equal(vtBuffer, 'mocked output buffer', 'returned single buffer');
+  module.composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
+    assert.equal(vtBuffer.length, bufferSF.length, 'same size');
+    assert.end();
   });
 });
 


### PR DESCRIPTION
Aims to resolve #8 by returning a `Nan::NewBuffer` instead of a `Nan::New<v8::String>`

This only adds the first two arguments to the `Nan::NewBuffer` method, which are `data`, and `size` - but there are two more options that can be added which relate to garbage collection - so we should be sure to do this properly if we can https://github.com/nodejs/nan/blob/master/doc/buffers.md#nannewbuffer - I'm just a little uncertain how to do it properly.

Separately: this would be a great addition to the node-cpp-skel examples, i.e. "return a buffer object" (similar to "ingest a buffer object" https://github.com/mapbox/node-cpp-skel/issues/67) 

cc @millzpaugh @artemp 