### PR TITLE
Pass v1 tiles through without marking as v2

### DIFF
--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -131,24 +131,7 @@ struct CompositeWorker : Nan::AsyncWorker
                             unsigned extent = layer.extent();
                             if (zoom_factor == 1)
                             {
-                                if (layer.version() == MVT_VERSION_2)
-                                    builder.add_existing_layer(layer);
-                                else
-                                {
-                                    // force v2
-                                    vtzero::layer_builder layer_builder{builder, name, MVT_VERSION_2, extent};
-                                    layer.for_each_feature([&](vtzero::feature const& feature) {
-                                        vtzero::geometry_feature_builder feature_builder{layer_builder};
-                                        if (feature.has_id()) feature_builder.set_id(feature.id());
-                                        feature_builder.set_geometry(feature.geometry());
-                                        feature.for_each_property([&feature_builder](vtzero::property const& p) {
-                                            feature_builder.add_property(p);
-                                            return true;
-                                        });
-                                        feature_builder.commit(); // temp work around for vtzero 1.0.1 regression
-                                        return true;
-                                    });
-                                }
+                                builder.add_existing_layer(layer);
                             }
                             else
                             {


### PR DESCRIPTION
The `vtcomposite` module supports V1 spec version tiles except in the case that we need to overzoom the layer and that layer contains features which contain polygons with invalid/non-simple geometries. In that case we'd expect an error from `boost::geometry::intersection`.

But besides that case, we can safely pass through v1 layers without a problem in the non-overzoomed case. I agree with @joto's comment at https://github.com/mapbox/vtcomposite/issues/47#issuecomment-402959072 that we should do this. No need to try to re-encode the whole layer just to force the version to be v2.

My thinking here is that this change:

 - Keeps vtcomposite highest performance
 - Delegates responsibility for dealing with v1 tiles outside the module

I think this is cleanest.

So, this PR partially reverts 0621ce52717d.

/cc @artemp @millzpaugh 