### PR TITLE
[TESTING/DO NOT MERGE] GeoJSON round trip debugger

### DIFF
--- a/bin/vtcomposite.js
+++ b/bin/vtcomposite.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var mapnik = require('mapnik');
+var fs = require('fs');
+var composite = require('../');
+var path = require('path');
+var diff = require('jest-diff');
+
+mapnik.register_datasource(path.join(mapnik.settings.paths.input_plugins,'geojson.input'));
+
+var vt = new mapnik.VectorTile(0,0,0);
+
+var input_file = process.argv[2];
+
+if (!input_file) {
+  console.error('please provide a path to a GeoJSON file');
+  process.exit(-1)
+}
+
+if (!fs.existsSync(input_file)) {
+  console.error('please provide a path to a GeoJSON file');
+  process.exit(-1)
+}
+
+vt.addGeoJSON(fs.readFileSync(process.argv[2]).toString(),'polygon')
+
+var tiles = [
+  { buffer:vt.getData(), z:0, x:0, y:0 }
+];
+
+fs.writeFileSync('input.mvt',vt.getData());
+
+const zxy = {z:0, x:0, y:0};
+var options = {buffer_size:0, reencode: true};
+
+var geojson_in = vt.toGeoJSON('__all__');
+//fs.writeFileSync('expected.json',JSON.stringify(JSON.parse(geojson_in),null,1))
+
+var target_vt = new mapnik.VectorTile(zxy.z, zxy.x, zxy.y);
+var source_tiles = new Array(tiles);
+for (var i = 0; i < tiles.length; ++i)
+{
+    var vt = new mapnik.VectorTile(tiles[i].z,tiles[i].x,tiles[i].y);
+    vt.addDataSync(tiles[i].buffer);
+    source_tiles[i] = vt;
+}
+
+composite(tiles, zxy, options, function(err, buf) {
+    if (err) throw err;
+    var vt2 = new mapnik.VectorTile(zxy.z,zxy.x,zxy.y);
+    vt2.addData(buf);
+    var geojson_out = vt2.toGeoJSON('__all__');
+    console.log('vtcomposite',diff(JSON.parse(geojson_in),JSON.parse(geojson_out)));
+    //fs.writeFileSync('actual-vt.json',JSON.stringify(JSON.parse(geojson_out),null,1))
+    target_vt.composite(source_tiles, options, function(err, vt2) {
+        if (err) throw err;
+        var geojson_out2 = vt2.toGeoJSON('__all__');
+        console.log('node-mapnik',diff(JSON.parse(geojson_in),JSON.parse(geojson_out2)));
+        //fs.writeFileSync('actual-mapnik.json',JSON.stringify(JSON.parse(geojson_out2),null,1))
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-FrQW7tY5SNywW2Hu1N1lvlo16W2ytsAL7wivMBF8elPvzpGldBzVc+JKrjefuxbTZnP9Wn/fvVmswiSaQC/Ckg==",
       "dev": true,
       "requires": {
-        "aws-sdk": "^2.4.11"
+        "aws-sdk": "2.245.1"
       }
     },
     "@mapbox/mvt-fixtures": {
@@ -19,11 +19,11 @@
       "integrity": "sha1-m66kvwUua4IZkT2kfj14b776t8E=",
       "dev": true,
       "requires": {
-        "@mapbox/sphericalmercator": "^1.0.5",
-        "@mapbox/vector-tile": "^1.3.0",
-        "d3-queue": "^3.0.7",
-        "pbf": "^3.0.5",
-        "protocol-buffers-schema": "^3.3.1"
+        "@mapbox/sphericalmercator": "1.1.0",
+        "@mapbox/vector-tile": "1.3.1",
+        "d3-queue": "3.0.7",
+        "pbf": "3.1.0",
+        "protocol-buffers-schema": "3.3.2"
       }
     },
     "@mapbox/point-geometry": {
@@ -44,7 +44,7 @@
       "integrity": "sha1-06dMkEAtBuiexm3knsgX/1NAlmY=",
       "dev": true,
       "requires": {
-        "@mapbox/point-geometry": "~0.1.0"
+        "@mapbox/point-geometry": "0.1.0"
       }
     },
     "@mapbox/vtinfo": {
@@ -53,9 +53,9 @@
       "integrity": "sha1-dfqsksfp/cJzafdd6c8zb7duuYg=",
       "dev": true,
       "requires": {
-        "nan": "^2.3.5",
-        "node-pre-gyp": "^0.6.28",
-        "protozero": "~1.4.1"
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.6.39",
+        "protozero": "1.4.5"
       },
       "dependencies": {
         "ajv": {
@@ -64,8 +64,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
           }
         },
         "assert-plus": {
@@ -86,7 +86,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "cryptiles": {
@@ -95,7 +95,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x"
+            "boom": "2.10.1"
           }
         },
         "form-data": {
@@ -104,9 +104,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
           }
         },
         "har-schema": {
@@ -121,8 +121,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
           }
         },
         "hawk": {
@@ -131,10 +131,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
-            "boom": "2.x.x",
-            "cryptiles": "2.x.x",
-            "hoek": "2.x.x",
-            "sntp": "1.x.x"
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
           }
         },
         "hoek": {
@@ -149,9 +149,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.1"
           }
         },
         "node-pre-gyp": {
@@ -160,17 +160,17 @@
           "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.2",
+            "detect-libc": "1.0.3",
             "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
             "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.1"
           }
         },
         "performance-now": {
@@ -191,28 +191,28 @@
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.2.1"
           }
         },
         "sntp": {
@@ -221,7 +221,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
-            "hoek": "2.x.x"
+            "hoek": "2.16.3"
           }
         },
         "tar": {
@@ -230,9 +230,9 @@
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         }
       }
@@ -247,16 +247,24 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "1.9.2"
+      }
     },
     "aproba": {
       "version": "1.2.0",
@@ -268,8 +276,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "asn1": {
@@ -351,7 +359,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "block-stream": {
@@ -360,7 +368,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "~2.0.0"
+        "inherits": "2.0.3"
       }
     },
     "boom": {
@@ -368,7 +376,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "brace-expansion": {
@@ -376,7 +384,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -386,9 +394,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
+        "base64-js": "1.3.0",
+        "ieee754": "1.1.11",
+        "isarray": "1.0.0"
       }
     },
     "bytes": {
@@ -401,6 +409,16 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.4.0"
+      }
     },
     "chownr": {
       "version": "1.0.1",
@@ -417,12 +435,25 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+    },
     "combined-stream": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "concat-map": {
@@ -445,7 +476,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.x.x"
+        "boom": "5.2.0"
       },
       "dependencies": {
         "boom": {
@@ -453,7 +484,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.x.x"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -468,7 +499,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -496,8 +527,8 @@
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "dev": true,
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
       }
     },
     "defined": {
@@ -521,13 +552,18 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "es-abstract": {
@@ -536,11 +572,11 @@
       "integrity": "sha1-zOh9UY8Elok7GjDNhGGDVTVIBoE=",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -549,10 +585,15 @@
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "events": {
       "version": "1.1.1",
@@ -570,7 +611,7 @@
       "resolved": "https://registry.npmjs.org/extfs/-/extfs-0.0.7.tgz",
       "integrity": "sha1-owgQ5HRZCg280NL0V63IkAnFwKs=",
       "requires": {
-        "underscore": ">= 1.4 < 2"
+        "underscore": "1.9.0"
       }
     },
     "extsprintf": {
@@ -594,7 +635,7 @@
       "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
       "dev": true,
       "requires": {
-        "is-function": "~1.0.0"
+        "is-function": "1.0.1"
       }
     },
     "foreach": {
@@ -613,9 +654,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "fs-extra": {
@@ -623,9 +664,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha1-DYUhIuW8W+tFP7Ao6cDJvzY0DJQ=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
       }
     },
     "fs-minipass": {
@@ -633,7 +674,7 @@
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
       "integrity": "sha1-BsJ3IYRU7CiN93raVKA7hwKqy50=",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.3"
       }
     },
     "fs.realpath": {
@@ -647,10 +688,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
       }
     },
     "fstream-ignore": {
@@ -659,9 +700,9 @@
       "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
       "dev": true,
       "requires": {
-        "fstream": "^1.0.0",
-        "inherits": "2",
-        "minimatch": "^3.0.0"
+        "fstream": "1.0.11",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4"
       }
     },
     "function-bind": {
@@ -675,14 +716,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
       }
     },
     "getpass": {
@@ -690,7 +731,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -698,12 +739,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -721,8 +762,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -731,8 +772,13 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -744,10 +790,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.x.x",
-        "cryptiles": "3.x.x",
-        "hoek": "4.x.x",
-        "sntp": "2.x.x"
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
       }
     },
     "hoek": {
@@ -760,9 +806,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "iconv-lite": {
@@ -770,7 +816,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "ieee754": {
@@ -784,7 +830,7 @@
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
       "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
       "requires": {
-        "minimatch": "^3.0.4"
+        "minimatch": "3.0.4"
       }
     },
     "inflight": {
@@ -792,8 +838,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -823,7 +869,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-function": {
@@ -838,7 +884,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.1"
       }
     },
     "is-symbol": {
@@ -861,6 +907,22 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jest-diff": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
+      "integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
+      "requires": {
+        "chalk": "2.4.1",
+        "diff": "3.5.0",
+        "jest-get-type": "22.4.3",
+        "pretty-format": "23.2.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
     },
     "jmespath": {
       "version": "0.15.0",
@@ -890,7 +952,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -903,7 +965,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsonify": {
@@ -936,8 +998,8 @@
       "dev": true,
       "requires": {
         "mapnik-vector-tile": "1.6.1",
-        "nan": "~2.8.0",
-        "node-pre-gyp": "~0.6.30",
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39",
         "protozero": "1.5.1"
       },
       "dependencies": {
@@ -952,17 +1014,17 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "detect-libc": "^1.0.2",
+            "detect-libc": "1.0.3",
             "hawk": "3.1.3",
-            "mkdirp": "^0.5.1",
-            "nopt": "^4.0.1",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.6",
             "request": "2.81.0",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^2.2.1",
-            "tar-pack": "^3.4.0"
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.1"
           },
           "dependencies": {
             "detect-libc": {
@@ -975,10 +1037,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "boom": "2.x.x",
-                "cryptiles": "2.x.x",
-                "hoek": "2.x.x",
-                "sntp": "1.x.x"
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
               },
               "dependencies": {
                 "boom": {
@@ -986,7 +1048,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.x.x"
+                    "hoek": "2.16.3"
                   }
                 },
                 "cryptiles": {
@@ -994,7 +1056,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "boom": "2.x.x"
+                    "boom": "2.10.1"
                   }
                 },
                 "hoek": {
@@ -1007,7 +1069,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "hoek": "2.x.x"
+                    "hoek": "2.16.3"
                   }
                 }
               }
@@ -1032,8 +1094,8 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "abbrev": "1",
-                "osenv": "^0.1.4"
+                "abbrev": "1.1.1",
+                "osenv": "0.1.5"
               },
               "dependencies": {
                 "abbrev": {
@@ -1046,8 +1108,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "os-homedir": "^1.0.0",
-                    "os-tmpdir": "^1.0.0"
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
                   },
                   "dependencies": {
                     "os-homedir": {
@@ -1069,10 +1131,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
               },
               "dependencies": {
                 "are-we-there-yet": {
@@ -1080,8 +1142,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.3.6"
                   },
                   "dependencies": {
                     "delegates": {
@@ -1094,13 +1156,13 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -1133,7 +1195,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "safe-buffer": "~5.1.0"
+                            "safe-buffer": "5.1.1"
                           }
                         },
                         "util-deprecate": {
@@ -1155,14 +1217,14 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
+                    "aproba": "1.2.0",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
                   },
                   "dependencies": {
                     "aproba": {
@@ -1190,9 +1252,9 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                       },
                       "dependencies": {
                         "code-point-at": {
@@ -1205,7 +1267,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "number-is-nan": "^1.0.0"
+                            "number-is-nan": "1.0.1"
                           },
                           "dependencies": {
                             "number-is-nan": {
@@ -1222,7 +1284,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                       },
                       "dependencies": {
                         "ansi-regex": {
@@ -1237,7 +1299,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "1.0.2"
                       }
                     }
                   }
@@ -1254,10 +1316,10 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "deep-extend": "~0.4.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
+                "deep-extend": "0.4.2",
+                "ini": "1.3.5",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
               },
               "dependencies": {
                 "deep-extend": {
@@ -1287,28 +1349,28 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aws-sign2": "~0.6.0",
-                "aws4": "^1.2.1",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.0",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.1.1",
-                "har-validator": "~4.2.1",
-                "hawk": "~3.1.3",
-                "http-signature": "~1.1.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.7",
-                "oauth-sign": "~0.8.1",
-                "performance-now": "^0.2.0",
-                "qs": "~6.4.0",
-                "safe-buffer": "^5.0.1",
-                "stringstream": "~0.0.4",
-                "tough-cookie": "~2.3.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.0.0"
+                "aws-sign2": "0.6.0",
+                "aws4": "1.7.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.4",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
               },
               "dependencies": {
                 "aws-sign2": {
@@ -1331,7 +1393,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "delayed-stream": "~1.0.0"
+                    "delayed-stream": "1.0.0"
                   },
                   "dependencies": {
                     "delayed-stream": {
@@ -1356,9 +1418,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "asynckit": "^0.4.0",
-                    "combined-stream": "^1.0.5",
-                    "mime-types": "^2.1.12"
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.6",
+                    "mime-types": "2.1.18"
                   },
                   "dependencies": {
                     "asynckit": {
@@ -1373,8 +1435,8 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "ajv": "^4.9.1",
-                    "har-schema": "^1.0.5"
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
                   },
                   "dependencies": {
                     "ajv": {
@@ -1382,8 +1444,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
                       },
                       "dependencies": {
                         "co": {
@@ -1396,7 +1458,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "jsonify": "~0.0.0"
+                            "jsonify": "0.0.0"
                           },
                           "dependencies": {
                             "jsonify": {
@@ -1420,9 +1482,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "assert-plus": "^0.2.0",
-                    "jsprim": "^1.2.2",
-                    "sshpk": "^1.7.0"
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.1",
+                    "sshpk": "1.14.1"
                   },
                   "dependencies": {
                     "assert-plus": {
@@ -1461,9 +1523,9 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "^1.0.0",
+                            "assert-plus": "1.0.0",
                             "core-util-is": "1.0.2",
-                            "extsprintf": "^1.2.0"
+                            "extsprintf": "1.3.0"
                           },
                           "dependencies": {
                             "core-util-is": {
@@ -1480,14 +1542,14 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "asn1": "~0.2.3",
-                        "assert-plus": "^1.0.0",
-                        "bcrypt-pbkdf": "^1.0.0",
-                        "dashdash": "^1.12.0",
-                        "ecc-jsbn": "~0.1.1",
-                        "getpass": "^0.1.1",
-                        "jsbn": "~0.1.0",
-                        "tweetnacl": "~0.14.0"
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
                       },
                       "dependencies": {
                         "asn1": {
@@ -1506,7 +1568,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "tweetnacl": "^0.14.3"
+                            "tweetnacl": "0.14.5"
                           }
                         },
                         "dashdash": {
@@ -1514,7 +1576,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "^1.0.0"
+                            "assert-plus": "1.0.0"
                           }
                         },
                         "ecc-jsbn": {
@@ -1523,7 +1585,7 @@
                           "dev": true,
                           "optional": true,
                           "requires": {
-                            "jsbn": "~0.1.0"
+                            "jsbn": "0.1.1"
                           }
                         },
                         "getpass": {
@@ -1531,7 +1593,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "assert-plus": "^1.0.0"
+                            "assert-plus": "1.0.0"
                           }
                         },
                         "jsbn": {
@@ -1570,7 +1632,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "mime-db": "~1.33.0"
+                    "mime-db": "1.33.0"
                   },
                   "dependencies": {
                     "mime-db": {
@@ -1610,7 +1672,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "punycode": "^1.4.1"
+                    "punycode": "1.4.1"
                   },
                   "dependencies": {
                     "punycode": {
@@ -1625,7 +1687,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "safe-buffer": "^5.0.1"
+                    "safe-buffer": "5.1.1"
                   }
                 },
                 "uuid": {
@@ -1640,7 +1702,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "glob": "^7.0.5"
+                "glob": "7.1.2"
               },
               "dependencies": {
                 "glob": {
@@ -1648,12 +1710,12 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "fs.realpath": "^1.0.0",
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "^3.0.4",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
                   },
                   "dependencies": {
                     "fs.realpath": {
@@ -1666,8 +1728,8 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -1687,7 +1749,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -1695,7 +1757,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "balanced-match": "^1.0.0",
+                            "balanced-match": "1.0.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -1718,7 +1780,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                       },
                       "dependencies": {
                         "wrappy": {
@@ -1747,9 +1809,9 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "block-stream": "*",
-                "fstream": "^1.0.2",
-                "inherits": "2"
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
               },
               "dependencies": {
                 "block-stream": {
@@ -1757,7 +1819,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "inherits": "~2.0.0"
+                    "inherits": "2.0.3"
                   }
                 },
                 "fstream": {
@@ -1765,10 +1827,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "inherits": "~2.0.0",
-                    "mkdirp": ">=0.5 0",
-                    "rimraf": "2"
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.2"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -1790,14 +1852,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "debug": "^2.2.0",
-                "fstream": "^1.0.10",
-                "fstream-ignore": "^1.0.5",
-                "once": "^1.3.3",
-                "readable-stream": "^2.1.4",
-                "rimraf": "^2.5.1",
-                "tar": "^2.2.1",
-                "uid-number": "^0.0.6"
+                "debug": "2.6.9",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.3.6",
+                "rimraf": "2.6.2",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
               },
               "dependencies": {
                 "debug": {
@@ -1820,10 +1882,10 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "graceful-fs": "^4.1.2",
-                    "inherits": "~2.0.0",
-                    "mkdirp": ">=0.5 0",
-                    "rimraf": "2"
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.2"
                   },
                   "dependencies": {
                     "graceful-fs": {
@@ -1843,9 +1905,9 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "fstream": "^1.0.0",
-                    "inherits": "2",
-                    "minimatch": "^3.0.0"
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
                   },
                   "dependencies": {
                     "inherits": {
@@ -1858,7 +1920,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                       },
                       "dependencies": {
                         "brace-expansion": {
@@ -1866,7 +1928,7 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "balanced-match": "^1.0.0",
+                            "balanced-match": "1.0.0",
                             "concat-map": "0.0.1"
                           },
                           "dependencies": {
@@ -1891,7 +1953,7 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "wrappy": "1"
+                    "wrappy": "1.0.2"
                   },
                   "dependencies": {
                     "wrappy": {
@@ -1906,13 +1968,13 @@
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "2.0.0",
+                    "safe-buffer": "5.1.1",
+                    "string_decoder": "1.1.1",
+                    "util-deprecate": "1.0.2"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -1945,7 +2007,7 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.1"
                       }
                     },
                     "util-deprecate": {
@@ -1983,15 +2045,15 @@
       "resolved": "https://registry.npmjs.org/mason-js-sdk/-/mason-js-sdk-0.1.4.tgz",
       "integrity": "sha1-vrC0YA4VBCT68uuUcEXl1YtweSE=",
       "requires": {
-        "d3-queue": "^3.0.7",
+        "d3-queue": "3.0.7",
         "extfs": "0.0.7",
-        "fs-extra": "^4.0.2",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.0",
-        "npmlog": "^4.1.2",
-        "request": "^2.83.0",
-        "tar": "^4.0.2"
+        "fs-extra": "4.0.3",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "needle": "2.2.1",
+        "npmlog": "4.1.2",
+        "request": "2.85.0",
+        "tar": "4.4.3"
       }
     },
     "mime-db": {
@@ -2004,7 +2066,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "minimatch": {
@@ -2012,7 +2074,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2025,8 +2087,8 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
       "integrity": "sha1-p9zIt7gz9dNodZzOVE3MtV9Q8jM=",
       "requires": {
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.0"
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "minizlib": {
@@ -2034,7 +2096,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.0.tgz",
       "integrity": "sha1-EeE2WM5GvDpwomeqxYNZ0eDCnOs=",
       "requires": {
-        "minipass": "^2.2.1"
+        "minipass": "2.3.3"
       }
     },
     "mkdirp": {
@@ -2067,9 +2129,9 @@
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.1.tgz",
       "integrity": "sha1-teMlvTqujCZ4kC+ilvcpRV0dOn0=",
       "requires": {
-        "debug": "^2.1.2",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
+        "debug": "2.6.9",
+        "iconv-lite": "0.4.23",
+        "sax": "1.2.4"
       }
     },
     "node-pre-gyp": {
@@ -2077,16 +2139,16 @@
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.10.2.tgz",
       "integrity": "sha512-16lql9QTqs6KsB9fl3neWyZm02KxIKdI9FlJjrB0y7eMTP5Nyz+xalwPbOlw3iw7EejllJPmlJSnY711PLD1ug==",
       "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "needle": "^2.2.0",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4"
+        "detect-libc": "1.0.3",
+        "mkdirp": "0.5.1",
+        "needle": "2.2.1",
+        "nopt": "4.0.1",
+        "npm-packlist": "1.1.10",
+        "npmlog": "4.1.2",
+        "rc": "1.2.7",
+        "rimraf": "2.6.2",
+        "semver": "5.5.0",
+        "tar": "4.4.3"
       }
     },
     "nopt": {
@@ -2094,8 +2156,8 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
       "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
       "requires": {
-        "abbrev": "1",
-        "osenv": "^0.1.4"
+        "abbrev": "1.1.1",
+        "osenv": "0.1.5"
       }
     },
     "npm-bundled": {
@@ -2108,8 +2170,8 @@
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.10.tgz",
       "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
       "requires": {
-        "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
+        "ignore-walk": "3.0.1",
+        "npm-bundled": "1.0.3"
       }
     },
     "npmlog": {
@@ -2117,10 +2179,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -2155,7 +2217,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "os-homedir": {
@@ -2173,8 +2235,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "path-is-absolute": {
@@ -2194,14 +2256,30 @@
       "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
       "dev": true,
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "1.1.11",
+        "resolve-protobuf-schema": "2.0.0"
       }
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pretty-format": {
+      "version": "23.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+      "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        }
+      }
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -2241,10 +2319,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
       "integrity": "sha1-ihDKMNWI0ARkNgNyuJDQbazQIpc=",
       "requires": {
-        "deep-extend": "^0.5.1",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.5.1",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "readable-stream": {
@@ -2252,13 +2330,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "request": {
@@ -2266,28 +2344,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
       "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "hawk": "~6.0.2",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "stringstream": "~0.0.5",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
       }
     },
     "resolve": {
@@ -2296,7 +2374,7 @@
       "integrity": "sha1-HwmsznlsmnYlefMbLBzEw83fnzY=",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-protobuf-schema": {
@@ -2305,7 +2383,7 @@
       "integrity": "sha1-5nsGKmfwLRG9aIbnDv2niEB+D7Q=",
       "dev": true,
       "requires": {
-        "protocol-buffers-schema": "^2.0.2"
+        "protocol-buffers-schema": "2.2.0"
       },
       "dependencies": {
         "protocol-buffers-schema": {
@@ -2322,7 +2400,7 @@
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "dev": true,
       "requires": {
-        "through": "~2.3.4"
+        "through": "2.3.8"
       }
     },
     "rimraf": {
@@ -2330,7 +2408,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "safe-buffer": {
@@ -2368,7 +2446,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.x.x"
+        "hoek": "4.2.1"
       }
     },
     "sphericalmercator": {
@@ -2382,14 +2460,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "string-width": {
@@ -2397,9 +2475,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string.prototype.trim": {
@@ -2408,9 +2486,9 @@
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0",
+        "function-bind": "1.1.1"
       }
     },
     "string_decoder": {
@@ -2418,7 +2496,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "stringstream": {
@@ -2431,7 +2509,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-json-comments": {
@@ -2439,25 +2517,33 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "3.0.0"
+      }
+    },
     "tape": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
       "integrity": "sha1-hVwINgOVEzcJ000/v57zQetzymo=",
       "dev": true,
       "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.2",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
-        "has": "~1.0.1",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.5.0",
-        "resolve": "~1.5.0",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.5.0",
+        "resolve": "1.5.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
       }
     },
     "tar": {
@@ -2465,13 +2551,13 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.3.tgz",
       "integrity": "sha512-LBw+tcY+/iCCTvF4i3SjqKWIgixSs/dB+Elg3BaY0MXh03D9jWclYskg3BiOkgg414NqpFI3nRgr2Qnw5jJs7Q==",
       "requires": {
-        "chownr": "^1.0.1",
-        "fs-minipass": "^1.2.5",
-        "minipass": "^2.3.3",
-        "minizlib": "^1.1.0",
-        "mkdirp": "^0.5.0",
-        "safe-buffer": "^5.1.2",
-        "yallist": "^3.0.2"
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.5",
+        "minipass": "2.3.3",
+        "minizlib": "1.1.0",
+        "mkdirp": "0.5.1",
+        "safe-buffer": "5.1.2",
+        "yallist": "3.0.2"
       }
     },
     "tar-pack": {
@@ -2480,14 +2566,14 @@
       "integrity": "sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==",
       "dev": true,
       "requires": {
-        "debug": "^2.2.0",
-        "fstream": "^1.0.10",
-        "fstream-ignore": "^1.0.5",
-        "once": "^1.3.3",
-        "readable-stream": "^2.1.4",
-        "rimraf": "^2.5.1",
-        "tar": "^2.2.1",
-        "uid-number": "^0.0.6"
+        "debug": "2.6.9",
+        "fstream": "1.0.11",
+        "fstream-ignore": "1.0.5",
+        "once": "1.4.0",
+        "readable-stream": "2.3.6",
+        "rimraf": "2.6.2",
+        "tar": "2.2.1",
+        "uid-number": "0.0.6"
       },
       "dependencies": {
         "tar": {
@@ -2496,9 +2582,9 @@
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         }
       }
@@ -2514,7 +2600,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "tunnel-agent": {
@@ -2522,7 +2608,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -2580,9 +2666,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "wide-align": {
@@ -2590,7 +2676,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "requires": {
-        "string-width": "^1.0.2"
+        "string-width": "1.0.2"
       }
     },
     "wrappy": {
@@ -2604,8 +2690,8 @@
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "dev": true,
       "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
+        "sax": "1.2.4",
+        "xmlbuilder": "4.2.1"
       }
     },
     "xmlbuilder": {
@@ -2614,7 +2700,7 @@
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "dev": true,
       "requires": {
-        "lodash": "^4.0.0"
+        "lodash": "4.17.10"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node-pre-gyp": "~0.10.2"
   },
   "devDependencies": {
+    "jest-diff": "^23.2.0",
     "@mapbox/cloudfriend": "^1.9.1",
     "@mapbox/mvt-fixtures": "^3.4.0",
     "@mapbox/sphericalmercator": "^1.1.0",

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -78,6 +78,7 @@ struct BatonType
     int y{};
     int buffer_size = 0;
     bool compress = false;
+    bool reencode = false;
 };
 
 struct CompositeWorker : Nan::AsyncWorker
@@ -129,7 +130,7 @@ struct CompositeWorker : Nan::AsyncWorker
                         {
                             names.push_back(name);
                             unsigned extent = layer.extent();
-                            if (zoom_factor == 1)
+                            if (zoom_factor == 1 && !baton_data_->reencode)
                             {
                                 builder.add_existing_layer(layer);
                             }
@@ -396,6 +397,15 @@ NAN_METHOD(composite)
                 return utils::CallbackError("'compress' must be a boolean", callback);
             }
             baton_data->compress = comp_value->BooleanValue();
+        }
+        if (options->Has(Nan::New("reencode").ToLocalChecked()))
+        {
+            v8::Local<v8::Value> reencode_value = options->Get(Nan::New("reencode").ToLocalChecked());
+            if (!reencode_value->IsBoolean())
+            {
+                return utils::CallbackError("'reencode' must be a boolean", callback);
+            }
+            baton_data->reencode = reencode_value->BooleanValue();
         }
     }
     // enter the threadpool, then done in the callback function call the threadpool


### PR DESCRIPTION
This implements #63. It also adds a `reencode` option to make sure the overzooming pathway is used. Without reencoding it is difficult to have the CLI always trigger overzooming. And it is the overzooming pathway that is potentially buggy and which we want to make sure is written correctly.

To use do:

```
./bin/vtcomposite.js <path/to/geojson>
```

It will assert that the GeoJSON passed in round trips. If round-tripping fails then it will output a diff, otherwise it outputs `Compared values have no visual difference`. Both `vtcomposite` and `node-mapnik` are tested.

The expected output, if no bugs are present, is:

```
$ ./bin/vtcomposite.js test/fixtures/four-points-z0.geojson 
vtcomposite Compared values have no visual difference.
node-mapnik Compared values have no visual difference.
```

Running the test on this file however:

```js
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              -175.078125,
              18.646245142670608
            ],
            [
              -8.4375,
              18.646245142670608
            ],
            [
              -8.4375,
              84.83422451455144
            ],
            [
              -175.078125,
              84.83422451455144
            ],
            [
              -175.078125,
              18.646245142670608
            ]
          ],
          [
            [
              -158.203125,
              52.05249047600099
            ],
            [
              -26.71875,
              52.05249047600099
            ],
            [
              -26.71875,
              80.05804956215623
            ],
            [
              -158.203125,
              80.05804956215623
            ],
            [
              -158.203125,
              52.05249047600099
            ]
          ]
        ]
      }
    }
  ]
}
```

Results in:

```
vtcomposite - Expected
+ Received

  Object {
    "features": Array [
      Object {
        "geometry": Object {
          "coordinates": Array [
            Array [
              Array [
                -8.4375,
                84.8342245145514,
              ],
              Array [
                -175.078125,
                84.8342245145514,
              ],
              Array [
                -175.078125,
                18.6462451426706,
              ],
              Array [
                -8.4375,
                18.6462451426706,
              ],
              Array [
                -8.4375,
                84.8342245145514,
              ],
            ],
-           Array [
-             Array [
-               -158.203125,
-               52.052490476001,
          ],
-             Array [
-               -158.203125,
-               80.0580495621562,
-             ],
-             Array [
-               -26.71875,
-               80.0580495621562,
-             ],
-             Array [
-               -26.71875,
-               52.052490476001,
-             ],
-             Array [
-               -158.203125,
-               52.052490476001,
-             ],
-           ],
-         ],
          "type": "Polygon",
        },
        "id": 1,
        "properties": Object {},
        "type": "Feature",
      },
    ],
    "type": "FeatureCollection",
  }
node-mapnik Compared values have no visual difference.
```

Since node-mapnik works correctly (and can round trip) while `vtcomposite` looses a polygon hole (refs #69)

This is not intended to merge, and rather intended to be a testing tool. For any bugs we find we should build back small testcases into the unit tests.

/cc @mapbox/core-tech 
