### PR TITLE
Add bench compression option

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,7 +1,6 @@
 "use strict";
 const zlib = require('zlib');
 const argv = require('minimist')(process.argv.slice(2));
-console.log('argv', argv)
 if (!argv.iterations || !argv.concurrency || !argv.package) {
   console.error('Please provide desired iterations, concurrency');
   console.error('Example: \nnode bench/bench.js --iterations 50 --concurrency 10 --package vtcomposite\nPackage options: vtcomposite or node-mapnik\nPass --compressed to bench compress tiles.');
@@ -61,7 +60,6 @@ function runRule(rule, ruleCallback) {
   function run(cb) {
     switch(argv.package){
       case 'vtcomposite':
-        // console.log(rule.tiles[0])
         composite(rule.tiles, rule.zxy, rule.options, function(err, result) {
           if (err) {
             throw err;

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,9 +1,10 @@
 "use strict";
-
+const zlib = require('zlib');
 const argv = require('minimist')(process.argv.slice(2));
+console.log('argv', argv)
 if (!argv.iterations || !argv.concurrency || !argv.package) {
   console.error('Please provide desired iterations, concurrency');
-  console.error('Example: \nnode bench/bench.js --iterations 50 --concurrency 10 --package vtcomposite\nPackage options: vtcomposite or node-mapnik');
+  console.error('Example: \nnode bench/bench.js --iterations 50 --concurrency 10 --package vtcomposite\nPackage options: vtcomposite or node-mapnik\nPass --compressed to bench compress tiles.');
   process.exit(1);
 }
 
@@ -32,8 +33,22 @@ const memstats = {
 
 // run each rule synchronously
 const ruleQueue = Queue(1);
+
 rules.forEach(function(rule) {
-  ruleQueue.defer(runRule, rule);
+  // console.log('rule not compressed');
+  if(argv.compress){
+    const newTiles = []
+    rule.tiles.forEach(function(t){
+      const compressedTile = zlib.gzipSync(t.buffer);
+      newTiles.push(compressedTile); 
+    });
+    rule.tiles = newTiles;
+    console.log('newTiles', newTiles);
+    ruleQueue.defer(runRule, rule);
+  }else{
+    console.log('rule.tiles', rule.tiles)
+    ruleQueue.defer(runRule, rule);
+  }
 });
 
 ruleQueue.awaitAll(function(err, res) {
@@ -51,6 +66,7 @@ function runRule(rule, ruleCallback) {
   function run(cb) {
     switch(argv.package){
       case 'vtcomposite':
+        // console.log(rule.tiles[0])
         composite(rule.tiles, rule.zxy, rule.options, function(err, result) {
           if (err) {
             throw err;

--- a/bench/bench.js
+++ b/bench/bench.js
@@ -35,18 +35,13 @@ const memstats = {
 const ruleQueue = Queue(1);
 
 rules.forEach(function(rule) {
-  // console.log('rule not compressed');
   if(argv.compress){
-    const newTiles = []
     rule.tiles.forEach(function(t){
       const compressedTile = zlib.gzipSync(t.buffer);
-      newTiles.push(compressedTile); 
+      t.buffer = compressedTile; 
     });
-    rule.tiles = newTiles;
-    console.log('newTiles', newTiles);
     ruleQueue.defer(runRule, rule);
   }else{
-    console.log('rule.tiles', rule.tiles)
     ruleQueue.defer(runRule, rule);
   }
 });

--- a/bench/rules.js
+++ b/bench/rules.js
@@ -5,14 +5,14 @@ const path = require('path');
 const mvtFixtures = require('@mapbox/mvt-fixtures');
 
 module.exports = [
-  {
-    description: 'single tile in/out',
-    options: {buffer_size: 128},
-    tiles: [
-      { z: 15, x: 5239, y: 12666, buffer: getTile('sanfrancisco', '15-5239-12666.mvt')}
-    ],
-    zxy: { z: 15, x: 5239, y: 12666}
-  },
+  // {
+  //   description: 'single tile in/out',
+  //   options: {buffer_size: 128},
+  //   tiles: [
+  //     { z: 15, x: 5239, y: 12666, buffer: getTile('sanfrancisco', '15-5239-12666.mvt')}
+  //   ],
+  //   zxy: { z: 15, x: 5239, y: 12666}
+  // },
   {
     description: 'two different tiles at the same zoom level, zero buffer',
     options: {buffer_size: 128},

--- a/bench/rules.js
+++ b/bench/rules.js
@@ -5,14 +5,14 @@ const path = require('path');
 const mvtFixtures = require('@mapbox/mvt-fixtures');
 
 module.exports = [
-  // {
-  //   description: 'single tile in/out',
-  //   options: {buffer_size: 128},
-  //   tiles: [
-  //     { z: 15, x: 5239, y: 12666, buffer: getTile('sanfrancisco', '15-5239-12666.mvt')}
-  //   ],
-  //   zxy: { z: 15, x: 5239, y: 12666}
-  // },
+  {
+    description: 'single tile in/out',
+    options: {buffer_size: 128},
+    tiles: [
+      { z: 15, x: 5239, y: 12666, buffer: getTile('sanfrancisco', '15-5239-12666.mvt')}
+    ],
+    zxy: { z: 15, x: 5239, y: 12666}
+  },
   {
     description: 'two different tiles at the same zoom level, zero buffer',
     options: {buffer_size: 128},

--- a/src/feature_builder.hpp
+++ b/src/feature_builder.hpp
@@ -249,7 +249,7 @@ struct overzoomed_feature_builder
         default:
             // LCOV_EXCL_START
             break;
-            // LCOV_EXCL_STOP        
+            // LCOV_EXCL_STOP
         }
     }
     vtzero::layer_builder& layer_builder_;


### PR DESCRIPTION
Adds the option to pass `--compress` in the bench script so compressed tiles are passed into the composite function. This mirrors our production environment. See #62 

cc @artemp @springmeyer 