### PR TITLE
Improves benchmark comparison

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -1,5 +1,4 @@
 "use strict";
-const zlib = require('zlib');
 const argv = require('minimist')(process.argv.slice(2));
 if (!argv.iterations || !argv.concurrency || !argv.package) {
   console.error('Please provide desired iterations, concurrency');
@@ -14,8 +13,10 @@ if (!argv.iterations || !argv.concurrency || !argv.package) {
 process.env.UV_THREADPOOL_SIZE = argv.concurrency;
 
 const fs = require('fs');
+const zlib = require('zlib');
 const path = require('path');
 const assert = require('assert');
+const bytes = require('bytes');
 const Queue = require('d3-queue').queue;
 const composite = require('../lib/index.js');
 const rules = require('./rules');
@@ -157,7 +158,7 @@ function runRule(rule, ruleCallback) {
     if (time == 0) {
       console.log("Warning: ms timer not high enough resolution to reliably track rate. Try more iterations");
     } else {
-    // number of milliseconds per iteration
+      // number of milliseconds per iteration
       var rate = runs/(time/1000);
       process.stdout.write(rate.toFixed(0) + ' runs/s (' + time + 'ms)');
     }
@@ -176,3 +177,12 @@ function log(message) {
     process.stdout.write(message);
   }
 }
+
+process.on('exit',function() {
+  if (track_mem) {
+    console.log('Benchmark peak mem (max_rss, max_heap, max_heap_total): ', bytes(memstats.max_rss), bytes(memstats.max_heap), bytes(memstats.max_heap_total));
+  } else {
+    console.log('Note: pass --mem to track memory usage');
+  }
+  console.log('Benchmark iterations:',argv.iterations,'concurrency:',argv.concurrency);
+})

--- a/bench/rules.js
+++ b/bench/rules.js
@@ -106,15 +106,6 @@ module.exports = [
     zxy: { z: 16, x: 10478, y: 25332}
   },
   {
-    description: 'returns compressed buffer - tiles completely made of points and linestrings, overzooming and lots of properties',
-    options: { compress:true, buffer_size: 128 },
-    tiles: [
-      { z: 15, x: 5239, y: 12666, buffer: fs.readFileSync('./test/fixtures/points-poi-sf-15-5239-12666.mvt')},
-      { z: 15, x: 5239, y: 12666, buffer: fs.readFileSync('./test/fixtures/linestrings-sf-15-5239-12666.mvt')}
-    ],
-    zxy: { z: 16, x: 10478, y: 25332}
-  },
-  {
     description: 'buffer_size 128 - tiles completely made of points and linestrings, overzooming and lots of properties',
     options: { buffer_size: 128 },
     tiles: [
@@ -144,15 +135,6 @@ module.exports = [
   {
     description: 'tiles completely made of polygons, overzooming (2x) and lots of properties',
     options: {buffer_size: 128 },
-    tiles: [
-      { z: 15, x: 5239, y: 12666, buffer: fs.readFileSync('./test/fixtures/polygons-buildings-sf-15-5239-12666.mvt')},
-      { z: 15, x: 5239, y: 12666, buffer: fs.readFileSync('./test/fixtures/polygons-hillshade-sf-15-5239-12666.mvt')}
-    ],
-    zxy: { z: 17, x: 20956, y: 50664}
-  },
-  {
-    description: 'return compressed buffer - tiles completely made of polygons, overzooming (2x) and lots of properties',
-    options: {compress:true, buffer_size: 128},
     tiles: [
       { z: 15, x: 5239, y: 12666, buffer: fs.readFileSync('./test/fixtures/polygons-buildings-sf-15-5239-12666.mvt')},
       { z: 15, x: 5239, y: 12666, buffer: fs.readFileSync('./test/fixtures/polygons-hillshade-sf-15-5239-12666.mvt')}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mapbox/tilebelt": "^1.0.1",
     "@mapbox/vector-tile": "^1.3.1",
     "aws-sdk": "^2.245.1",
-    "bytes": "^2.4.0",
+    "bytes": "^2.5.0",
     "d3-queue": "^3.0.1",
     "mapnik": "3.6.1",
     "minimist": "~1.2.0",


### PR DESCRIPTION
This fixes a few issues in the benchmark script:

 - Option to test compositing from compressed tiles is called `--compress` but usage said `--compressed`
 - `vtcomposite` mode was not tracking memory and memory stats were not output at all
 - We were using `vt.addDataSync` for node-mapnik, whereas in production we use the async `vt.addData` due to https://github.com/mapbox/tilelive-vector/blob/master/backend.js#L113 (which means that `gzip decompression` is async)
 - refactors code to avoid duplication between `vtcomposite` and `node-mapnik` modes