### PR TITLE
Property mapper

### DIFF
--- a/src/feature_builder.hpp
+++ b/src/feature_builder.hpp
@@ -43,7 +43,7 @@ struct point_handler
     {
         CoordinateType x = pt.x * zoom_factor_ - dx_;
         CoordinateType y = pt.y * zoom_factor_ - dy_;
-        mapbox::geometry::point<CoordinateType> pt0{x,y};
+        mapbox::geometry::point<CoordinateType> pt0{x, y};
         if (boost::geometry::covered_by(pt0, bbox_))
         {
             geom_.push_back(std::move(pt0));

--- a/src/feature_builder.hpp
+++ b/src/feature_builder.hpp
@@ -33,10 +33,6 @@ struct point_handler
 
     void points_begin(std::uint32_t count)
     {
-        if (count > 1)
-        {
-            geom_.reserve(count);
-        }
     }
 
     void points_point(vtzero::point const& pt)

--- a/src/feature_builder.hpp
+++ b/src/feature_builder.hpp
@@ -192,9 +192,9 @@ struct overzoomed_feature_builder
                             last_pt = *itr;
                         }
                     }
-              }
-              if (valid) finalize(feature_builder, feature);
+                }
             }
+            if (valid) finalize(feature_builder, feature);
         }
     }
     void apply_geometry_polygon(vtzero::feature const& feature)

--- a/src/feature_builder.hpp
+++ b/src/feature_builder.hpp
@@ -7,7 +7,6 @@
 #include <vtzero/builder.hpp>
 #include <vtzero/property_mapper.hpp>
 // boost
-#include <boost/core/ignore_unused.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 // stl
@@ -31,7 +30,7 @@ struct point_handler
     {
     }
 
-    void points_begin(std::uint32_t count)
+    void points_begin(std::uint32_t)
     {
     }
 

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -144,10 +144,10 @@ struct CompositeWorker : Nan::AsyncWorker
                                                                             {static_cast<int>(extent) + buffer_size,
                                                                              static_cast<int>(extent) + buffer_size}};
                                 vtile::overzoomed_feature_builder<coordinate_type> feature_builder{layer_builder, mapper, bbox, dx, dy, zoom_factor};
-                                while (auto feature = layer.next_feature())
-                                {
-                                    feature_builder.apply(feature);
-                                }
+                                layer.for_each_feature([&](vtzero::feature const& feature) {
+                                  feature_builder.apply(feature);
+                                  return true;
+                                });
                             }
                         }
                     }

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -136,17 +136,18 @@ struct CompositeWorker : Nan::AsyncWorker
                             else
                             {
                                 vtzero::layer_builder layer_builder{builder, name, MVT_VERSION_2, extent};
+                                vtzero::property_mapper mapper{layer, layer_builder};
                                 using coordinate_type = std::int64_t;
                                 int dx, dy;
                                 std::tie(dx, dy) = vtile::displacement(tile_obj->z, static_cast<int>(extent), target_z, target_x, target_y);
                                 mapbox::geometry::box<coordinate_type> bbox{{-buffer_size, -buffer_size},
                                                                             {static_cast<int>(extent) + buffer_size,
                                                                              static_cast<int>(extent) + buffer_size}};
-                                vtile::overzoomed_feature_builder<coordinate_type> feature_builder{layer_builder, bbox, dx, dy, zoom_factor};
-                                layer.for_each_feature([&](vtzero::feature const& feature) {
+                                vtile::overzoomed_feature_builder<coordinate_type> feature_builder{layer_builder, mapper, bbox, dx, dy, zoom_factor};
+                                while (auto feature = layer.next_feature())
+                                {
                                     feature_builder.apply(feature);
-                                    return true;
-                                });
+                                }
                             }
                         }
                     }

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -145,8 +145,8 @@ struct CompositeWorker : Nan::AsyncWorker
                                                                              static_cast<int>(extent) + buffer_size}};
                                 vtile::overzoomed_feature_builder<coordinate_type> feature_builder{layer_builder, mapper, bbox, dx, dy, zoom_factor};
                                 layer.for_each_feature([&](vtzero::feature const& feature) {
-                                  feature_builder.apply(feature);
-                                  return true;
+                                    feature_builder.apply(feature);
+                                    return true;
                                 });
                             }
                         }


### PR DESCRIPTION
This updates the code to optimize the copying of feature properties by leveraging the `vtzero::property_mapper` and specifically the new interface @joto added in https://github.com/mapbox/vtzero/commit/184bb33e10a42071211117df176db5aebbf97c3b and https://github.com/mapbox/vtzero/commit/29157250538f3a6ddf4abd73f35d0020a543f827 to be able to work with `const&` features. Closes #68

On OS X this gives a 1.3x speedup for the `tiles completely made of points, overzoooming, lots of properties` benchmark rule:

Before this change:

```
$ time node bench/bench.js --iterations 5000 --concurrency 1 --package vtcomposite --mem

1: tiles completely made of points, overzoooming, lots of properties ... 1588 runs/s (3149ms)
Benchmark peak mem (max_rss, max_heap, max_heap_total):  101.55MB 10.38MB 17.83MB
Benchmark iterations: 5000 concurrency: 1

real	0m3.341s
user	0m3.281s
sys	0m0.138s
```

After this change:

```
$ time node bench/bench.js --iterations 5000 --concurrency 1 --package vtcomposite --mem

1: tiles completely made of points, overzoooming, lots of properties ... 2056 runs/s (2432ms)
Benchmark peak mem (max_rss, max_heap, max_heap_total):  101.48MB 10.44MB 17.83MB
Benchmark iterations: 5000 concurrency: 1

real	0m2.584s
user	0m2.583s
sys	0m0.126s
```

/cc @artemp @millzpaugh @alliecrevier 