### PR TITLE
Actually pass buffer size

### DIFF
--- a/bench/bench.js
+++ b/bench/bench.js
@@ -105,9 +105,11 @@ function runRule(rule, ruleCallback) {
         break;
       case 'node-mapnik':
         var target_vt = new mapnik.VectorTile(rule.zxy.z, rule.zxy.x, rule.zxy.y);
+        target_vt.bufferSize = rule.options.buffer_size;
         let addDataQueue = Queue();
         function addData(tile,done) {
           var vt = new mapnik.VectorTile(tile.z,tile.x,tile.y);
+          vt.bufferSize = rule.options.buffer_size;
           vt.addData(tile.buffer,function(err) {
              if (err) throw err;
              return done(null,vt);


### PR DESCRIPTION
https://github.com/mapbox/vtcomposite/commit/eaabc849e7cc0ffe5e7579406012c51778340d35#diff-ce5dbd4e58e925e4544e69f030e1ca4b incorrectly removed the passing of `buffer_size` to node-mapnik. This re-introduces it.

So, before this change, for all benchmarks that were testing with a `buffer_size` that was not the default, we've been 🍎 to 🍊 as far as comparing node-mapnik to vtcomposite.

/cc @artemp @millzpaugh 