### PR TITLE
Fail fast in tests

### DIFF
--- a/test/vtcomposite-linestrings.test.js
+++ b/test/vtcomposite-linestrings.test.js
@@ -19,19 +19,20 @@ test('[composite] overzooming success (linestring), no buffer - different zooms 
   const zxy = {z:1, x:0, y:0};
 
   composite(tiles, zxy, {buffer_size:128}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
 
     assert.deepEqual(
-      outputInfo.layers.quadrants.feature(0).loadGeometry()[0][0], 
-      { x: 784, y: 1848 }, 
+      outputInfo.layers.quadrants.feature(0).loadGeometry()[0][0],
+      { x: 784, y: 1848 },
       'first feature scales as expected'
     );
 
     assert.deepEqual(
-      { x: 4224, y: 3398 }, 
+      { x: 4224, y: 3398 },
       outputInfo.layers.quadrants.feature(0).loadGeometry()[0][1],
       'check that new coordinates shifted properly (since zoom factor is 3)'
-    ); 
+    );
 
     assert.end();
   });
@@ -51,19 +52,20 @@ test('[composite] overzooming success (linestring), with buffer - different zoom
   const zxy = {z:1, x:0, y:0};
 
   composite(tiles, zxy, {buffer_size:128}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
 
     assert.deepEqual(
-      outputInfo.layers.quadrants.feature(0).loadGeometry()[0][0], 
-      { x: 784, y: 1848 }, 
+      outputInfo.layers.quadrants.feature(0).loadGeometry()[0][0],
+      { x: 784, y: 1848 },
       'first feature scales as expected'
     );
 
     assert.deepEqual(
-      { x: 4224, y: 3398 }, 
+      { x: 4224, y: 3398 },
       outputInfo.layers.quadrants.feature(0).loadGeometry()[0][1],
       'check that new coordinates shifted properly (since zoom factor is 3)'
-    ); 
+    );
 
     assert.end();
   });

--- a/test/vtcomposite-multis.test.js
+++ b/test/vtcomposite-multis.test.js
@@ -22,6 +22,7 @@ test('[composite] composite success multi geometries - different layer name, dif
   assert.equal(info2.layers.seeya.length, 1);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.goodbye.length, 1);
     assert.equal(outputInfo.layers.seeya.length, 1);
@@ -48,6 +49,7 @@ test('[composite] composite success multi geometries - different layer name, dif
   assert.equal(info2.layers.seeya.length, 1);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(vtBuffer.length, 171);
     assert.equal(outputInfo.layers.goodbye.length, 1);
@@ -74,10 +76,12 @@ test('[composite] composite and overzooming success multi geometries - different
   assert.equal(info2.layers.seeya.length, 1);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(Object.keys(outputInfo.layers).length, 1);
 
     composite(tiles, zxy, {'buffer_size': 4096}, (err, vtBuffer) => {
+      assert.notOk(err);
       const outputInfo = vtinfo(vtBuffer);
       assert.equal(vtBuffer.length, 181);
       assert.equal(Object.keys(outputInfo.layers).length, 3);
@@ -104,10 +108,12 @@ test('[composite] composite and overzooming success multi geometries with v1 til
   assert.equal(info2.layers.seeya.length, 1);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(Object.keys(outputInfo.layers).length, 1);
 
     composite(tiles, zxy, {'buffer_size': 4096}, (err, vtBuffer) => {
+      assert.notOk(err);
       const outputInfo = vtinfo(vtBuffer);
       assert.equal(vtBuffer.length, 181);
       assert.equal(Object.keys(outputInfo.layers).length, 3);

--- a/test/vtcomposite-points.test.js
+++ b/test/vtcomposite-points.test.js
@@ -28,12 +28,12 @@ test('[composite] success compositing - different layer name, different features
   const zxy = {z:15, x:5238, y:12666};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(vtBuffer.length, 110);
     assert.ok(outputInfo.layers.hello, 'expected layer name');
     assert.ok(outputInfo.layers['clipped-square'], 'expected layer name');
     assert.equal(Object.keys(outputInfo.layers).length, 2, 'expected number of layers');
-    assert.notOk(err);
     assert.end();
   });
 });
@@ -52,6 +52,7 @@ test('[composite] success overzooming - different zooms between two tiles, no bu
   const zxy = {z:1, x:0, y:0};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(vtBuffer.length, 57);
     assert.equal(outputInfo.layers.quadrants.length, 1,'clips all but one feature when overzooming');
@@ -89,6 +90,7 @@ test('[composite] overzooming success - overzooming zoom factor of 4 between two
   const latInt = Math.round(parseFloat('.' + (lat2tile(lat,zxy.z)).toString().split('.')[1])*4096);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(vtBuffer.length, 57);
     assert.equal(outputInfo.layers.quadrants.length, 1,'clips all but one feature when overzooming');

--- a/test/vtcomposite-polygons.test.js
+++ b/test/vtcomposite-polygons.test.js
@@ -21,12 +21,14 @@ test('[composite] composite success polygons - same zoom, different features, wi
   assert.equal(info2.layers.poi_label.length, 14);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.building.length, 1718);
     assert.equal(outputInfo.layers.hillshade.length, 17);
     assert.equal(outputInfo.layers.poi_label.length, 14);
 
     composite(tiles, zxy, {buffer_size:128}, (err, vtBuffer) => {
+      assert.notOk(err);
       const outputInfoWithBuffer = vtinfo(vtBuffer);
       assert.equal(outputInfo.layers.building.length, 1718);
       assert.equal(outputInfo.layers.hillshade.length, 17);
@@ -53,12 +55,14 @@ test('[composite] composite and overzooming success polygons - overzooming zoom 
   assert.equal(info2.layers.poi_label.length, 14);
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.building.length, 238);
     assert.equal(outputInfo.layers.hillshade.length, 11);
     assert.equal(outputInfo.layers.poi_label.length, 14);
 
     composite(tiles, zxy, {buffer_size:128}, (err, vtBuffer) => {
+      assert.notOk(err);
       const outputInfoWithBuffer = vtinfo(vtBuffer);
 
       assert.equal(outputInfoWithBuffer.layers.building.length, 275);
@@ -84,6 +88,7 @@ test('[composite] composite and overzooming success polygons - overzooming multi
   assert.equal(coords.length, 23);
 
   composite(tiles, zxy, {buffer_size: 5000}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.hillshade.length, 1);
     var hillshade = outputInfo.layers.hillshade;
@@ -113,6 +118,7 @@ test('[composite] composite and overzooming success polygons - overzooming polyg
   assert.equal(coords.length, 2);
 
   composite(tiles, zxy, {buffer_size: 0}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.polygon.length, 1);
     var polygon_layer = outputInfo.layers.polygon;

--- a/test/vtcomposite.test.js
+++ b/test/vtcomposite.test.js
@@ -37,12 +37,12 @@ test('[composite] success compositing - same layer name, same features, same zoo
   const zxy = {z:15, x:5238, y:12666};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
 
     assert.ok(outputInfo.layers.hello, 'hello', 'expected layer name');
     assert.equal(Object.keys(outputInfo.layers).length, 1, 'expected number of layers');
     assert.equal(outputInfo.layers.hello.length, 1, 'expected number of features');
-    assert.notOk(err);
     assert.end();
   });
 });
@@ -59,13 +59,13 @@ test('[composite] success compositing - same layer name, different features, sam
   const zxy = {z:15, x:5238, y:12666};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
 
     assert.ok(outputInfo.layers.water, 'returns layer water');
     assert.equal(Object.keys(outputInfo.layers).length, 1, 'return 1 layers');
     assert.equal(outputInfo.layers.water.length, 1, 'only has one feature');
     assert.equal(outputInfo.layers.water.feature(0).properties.name, 'mud lake', 'expected feature');
-    assert.notOk(err);
     assert.end();
   });
 });
@@ -170,6 +170,7 @@ test('[composite] underzooming generates out of bounds error', function(assert) 
   const zxy = {z:0, x:0, y:0};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.ok(err);
     assert.equal(err.message, 'Invalid tile composite request: SOURCE(3,1,1) TARGET(0,0,0)')
     assert.end();
   });
@@ -190,7 +191,7 @@ test('[composite] huge overzoom z0 - z14', function(assert) {
   const zxy = {z:overzoomedZXY[2], x:overzoomedZXY[0], y:overzoomedZXY[1]};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
-    if (err) throw err;
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.quadrants.length, 1);
     assert.end();
@@ -212,7 +213,7 @@ test('[composite] huge overzoom z15 - z27', function(assert) {
   const zxy = {z:overzoomedZXY[2], x:overzoomedZXY[0], y:overzoomedZXY[1]};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
-    if (err) throw err;
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(outputInfo.layers.poi_label.length, 1);
     assert.end();
@@ -233,7 +234,7 @@ test('[composite] processing V1 tiles with malformed geometries', function(asser
   const zxy = {z:14, x:4396, y:6458};
 
   composite(tiles, zxy, {}, (err, vtBuffer) => {
-    if (err) throw err;
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     var count = 0;
     for (var name in outputInfo.layers)
@@ -259,7 +260,7 @@ test('[composite] resolves zero length linestring error for overzoomed V1 tiles 
   const zxy = {z:14, x:5088, y:5937};
 
   composite(tiles, zxy, {buffer_size:4080}, (err, vtBuffer) => {
-    if (err) throw err;
+    assert.notOk(err);
     const outputInfo = vtinfo(vtBuffer);
     assert.equal(Object.keys(outputInfo.layers).length, 11, 'v1 tiles with polygons composite successfully');
     assert.end();
@@ -283,7 +284,7 @@ if (!process.env.ASAN_OPTIONS) {
     const zxy = {z:4, x:8, y:5};
 
     composite(tiles, zxy, {buffer_size:4080}, (err, vtBuffer) => {
-      if (err) throw err;
+      assert.notOk(err);
       const outputInfo = vt1infoValid(vtBuffer);
       assert.equal(Object.keys(outputInfo.layers).length, 7, 'v1 tiles with polygons composite successfully');
       assert.end();


### PR DESCRIPTION
This ensures that all tests are consistently asserting either `assert.notOk(err);` or `assert.ok(err);`. Without these asserts when an error is throw unexpectedly it makes debugging the test failure hard. This should ensure the tests [fail fast](https://en.wikipedia.org/wiki/Fail-fast) for easiest debugging and iteration.