### PR TITLE
0.2.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.2.1-dev1",
+  "version": "0.2.1-dev2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.2.1-dev1",
+  "version": "0.2.1-dev2",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",


### PR DESCRIPTION
Generating 0.2.1 binaries, which includes three fixes:

* https://github.com/mapbox/vtcomposite/commit/df0f462fb1f3bb44106882f6da7b141ab0434545
* https://github.com/mapbox/vtcomposite/issues/98
* https://github.com/mapbox/vtcomposite/pull/101

cc @springmeyer @artemp @ericfischer @millzpaugh @ian29 