### PR TITLE
0.2.1 official release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.1
+
+- Revert polygon decoding PR that snuck into 0.2.0 release [#91](https://github.com/mapbox/vtcomposite/pull/91)
+- Remove `valid=false`, which fixes a linestring clipping bug [#98](https://github.com/mapbox/vtcomposite/pull/98)
+- Polygon clipping fix [#101](https://github.com/mapbox/vtcomposite/pull/101)
+
 # 0.2.0
 
 - Upgrade to use N-API and remove nan/node-pre-gyp deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.2.1-dev2",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.2.1-dev2",
+  "version": "0.2.1",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",


### PR DESCRIPTION
Branch protections prevented me from releasing 0.2.1 directly on master, hence the accidental early merge of #103 and the opening of this PR. 

Will look for ✅ once binaries are published!

cc @springmeyer @artemp @flippmoke @ericfischer @millzpaugh @ian29 