### PR TITLE
add same layer test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.1
+
+- Bugfix for v0.5.0 to fix an issue where compositing multiple tiles with specific layers included would drop same-named layers [#114](https://github.com/mapbox/vtcomposite/pull/114)
+
 # 0.5.0
 
 - Add `buffers[n].layers` array to allow keeping of specific layers during compositing [#113](https://github.com/mapbox/vtcomposite/pull/113)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.5.0-dev2",
+  "version": "0.5.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.5.1-0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.5.0",
+  "version": "0.5.1-0",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "0.5.1-0",
+  "version": "0.5.1",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -178,14 +178,13 @@ struct CompositeWorker : Napi::AsyncWorker
                         std::uint32_t const version = layer.version();
                         if (std::find(std::begin(names), std::end(names), name) == std::end(names))
                         {
-                            names.push_back(name);
-
                             // should we keep this layer?
                             // if include_layers is empty, keep all layers
                             // if include_layers is not empty, keep layer if we can find its name in the vector
                             std::string sname(name);
                             if (include_layers.empty() || std::find(std::begin(include_layers), std::end(include_layers), sname) != std::end(include_layers))
                             {
+                                names.push_back(name);
                                 std::uint32_t extent = layer.extent();
                                 if (zoom_factor == 1)
                                 {

--- a/test/vtcomposite.test.js
+++ b/test/vtcomposite.test.js
@@ -352,3 +352,18 @@ test('[composite] success: composite and drop layers', function(assert) {
     assert.end();
   });
 });
+
+test('[composite] success: composite and drop same layer names', function(assert) {
+  const tiles = [
+    { buffer: bufferSF, z:15, x:5238, y:12666, layers: ['building'] },
+    { buffer: bufferSF, z:15, x:5238, y:12666, layers: ['poi_label'] }
+  ];
+
+  const zxy = {z:15, x:5238, y:12666};
+
+  composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
+    assert.deepEqual(Object.keys(vtinfo(vtBuffer).layers), ['building', 'poi_label'], 'expected layers');
+    assert.end();
+  });
+});

--- a/test/vtcomposite.test.js
+++ b/test/vtcomposite.test.js
@@ -367,3 +367,18 @@ test('[composite] success: composite and drop same layer names', function(assert
     assert.end();
   });
 });
+
+test('[composite] success: composite and drop same layer names reversed', function(assert) {
+  const tiles = [
+    { buffer: bufferSF, z:15, x:5238, y:12666, layers: ['poi_label'] },
+    { buffer: bufferSF, z:15, x:5238, y:12666, layers: ['building'] }
+  ];
+
+  const zxy = {z:15, x:5238, y:12666};
+
+  composite(tiles, zxy, {}, (err, vtBuffer) => {
+    assert.notOk(err);
+    assert.deepEqual(Object.keys(vtinfo(vtBuffer).layers), ['poi_label', 'building'], 'expected layers');
+    assert.end();
+  });
+});

--- a/test/vtcomposite.test.js
+++ b/test/vtcomposite.test.js
@@ -333,7 +333,7 @@ test('[composite] success: drop layers if "layers" array is in tiles object', fu
   composite(tiles, zxy, {}, (err, vtBuffer) => {
     assert.notOk(err);
     assert.deepEqual(Object.keys(vtinfo(vtBuffer).layers), ['building', 'poi_label'], 'expected layers');
-    assert.notEqual(vtBuffer.length, bufferSF.length, 'buffer is not of the same sie');
+    assert.notEqual(vtBuffer.length, bufferSF.length, 'buffer is not of the same size');
     assert.end();
   });
 });


### PR DESCRIPTION
- fixes bug where compositing 2 tilesets with the same layer names, but selecting different layers from each, would ignore the second tileset's layers even if the first tileset's layers were dropped.
- adds test for same layer names

Next steps:
- [ ] get PR approved
- [ ] release `0.5.1`
- [ ] merge