### PR TITLE
configurable language settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,15 @@ A filtering function for modifying a tile's features and properties to support l
 - `params` **Object**
   - `params.buffer` **Buffer** a vector tile buffer, gzip compressed or not
   - `params.compress` **Boolean** a boolean value indicating whether or not to return a compressed buffer. Default is to return an uncompressed buffer. (optional, default `false`)
-  - `params.language` **String** the IETF BCP 47 language code.
+  - `params.language` **String** the IETF BCP 47 language code used to search for matching translations available in a feature's properties. All language-related properties must match the following format: `{language_prefix}{language_property}_{language}`. Default properties are `_mbx_name_{language}`. Example `_mbx_name_jp` property includes the Japanese translation for the value in `name`.
+    - If a feature has a matching translation, the feature redefines the `{language_property}` to the value of the discovered translation.
+    - If a feature has a matching translation, the original value from `{language_property}` is retained in a newly created value `{language_property}_local`.
+    - If a translation is from a property _without_ a `{language_prefix}`, the property is retained in the final tile.
+    - If a translation is from a property _with_ a `{language_prefix}`, the property is dropped in the final tile. This allows users to add as many languages as desired to the vector tile and eventually drop them before using the tile.
+    - If a feature does not have a matching translation, no fields are modified.
+    - In any case, all fields with a property that matches `{language_prefix}` are dropped from the final tile, even if they do not pertain to language translations.
+  - `params.language_property` **String** the primary property in features that identifies the feature in a language. Default `name`. This values is used to search for additional translations that match the following format `{language_property}_{language}`
+  - `params.language_prefix` **String** prefix for any additional translation properties. The value is used to search for additional translations that match the following format: `{language_prefix}{language_property}_{language}`.
   - `params.worldview` **Array<String>** array of ISO 3166-1 alpha-2 country codes used to filter out features of different worldviews. Worldview data must be included in the vector tile. See `params.worldview_property` for more details on encoding data.
     - If a feature matches one of the requested worldviews, the feature is kept. It will have a property `worldview` equal to the matching worldview value and the `params.worldview_property` property will be dropped. If the original feature contained a `worldview` property, it is overwritten.
     - If a feature has a worldview value of `all` it is considered a match and `worldview: all` is added to the feature's properties and the `params.worldview_property` property is dropped. If the original feature contains a `worldview` property, it is ovewritten.

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -96,14 +96,16 @@ struct LocalizeBatonType
 {
     LocalizeBatonType(Napi::Buffer<char> const& buffer,
                       std::string language_,
-                      bool change_names_,
+                      std::string language_property_,
+                      std::string language_prefix_,
                       std::vector<std::string> worldviews_,
                       std::string worldview_property_,
                       bool compress_)
         : data{buffer.Data(), buffer.Length()},
           buffer_ref{Napi::Persistent(buffer)},
           language{std::move(language_)},
-          change_names{change_names_},
+          language_property{std::move(language_property_)},
+          language_prefix{std::move(language_prefix_)},
           worldviews{std::move(worldviews_)},
           worldview_property{std::move(worldview_property_)},
           compress{compress_}
@@ -131,7 +133,8 @@ struct LocalizeBatonType
     vtzero::data_view data;
     Napi::Reference<Napi::Buffer<char>> buffer_ref;
     std::string language;
-    bool change_names;
+    std::string language_property;
+    std::string language_prefix;
     std::vector<std::string> worldviews;
     std::string worldview_property;
     bool compress;
@@ -657,11 +660,13 @@ struct LocalizeWorker : Napi::AsyncWorker
         {
             vtzero::tile_builder tbuilder;
             std::string language_key;
-            std::string language_key_mbx;
-            if (baton_data_->change_names)
+            std::string language_key_prefixed;
+            if (!baton_data_->language.empty())
             {
-                language_key = "name_" + baton_data_->language;
-                language_key_mbx = "_mbx_name_" + baton_data_->language;
+                // {language_property}_{language} -> retain
+                language_key = baton_data_->language_property + "_" + baton_data_->language;
+                // {language_prefix}{language_property}_{language} -> drop
+                language_key_prefixed = baton_data_->language_prefix + language_key;
             }
             std::vector<char> buffer_cache;
             vtzero::data_view tile_view{};
@@ -705,36 +710,36 @@ struct LocalizeWorker : Napi::AsyncWorker
                             continue;
                         }
 
-                        // preserve original name value
-                        if (property_key == "name")
+                        // preserve original params.language_property value
+                        if (property_key == baton_data_->language_property)
                         {
                             name_value = property.value();
 
                             // if no language was specified, we want the name value to be constant
-                            if (!baton_data_->change_names)
+                            if (baton_data_->language.empty())
                             {
-                                properties.emplace_back("name", property.value());
+                                properties.emplace_back(baton_data_->language_property, property.value());
                                 name_was_set = true;
                             }
                             continue;
                         }
-                        // set name to _mbx_name_{language}, if existing
-                        if (baton_data_->change_names && !name_was_set && language_key_mbx == property_key)
+                        // set name to value from {prefix}{language_property}_{language}, if existing
+                        if (!baton_data_->language.empty() && !name_was_set && language_key_prefixed == property_key)
                         {
-                            properties.emplace_back("name", property.value());
+                            properties.emplace_back(baton_data_->language_property, property.value());
                             name_was_set = true;
                             continue;
                         }
-                        // remove _mbx prefixed properties
-                        if (property_key.find("_mbx_") == 0) // NOLINT(abseil-string-find-startswith)
+                        // remove any properties that starts with the given params.language_prefix value
+                        if (property_key.find(baton_data_->language_prefix) == 0) // NOLINT(abseil-string-find-startswith)
                         {
                             continue;
                         }
-                        // set name to name_{language}, if existing
+                        // set name to {language_property}_{language}, if existing
                         // and keep these legacy properties on the feature
-                        if (baton_data_->change_names && !name_was_set && language_key == property_key)
+                        if (!baton_data_->language.empty() && !name_was_set && language_key == property_key)
                         {
-                            properties.emplace_back("name", property.value());
+                            properties.emplace_back(baton_data_->language_property, property.value());
                             name_was_set = true;
                         }
 
@@ -743,11 +748,12 @@ struct LocalizeWorker : Napi::AsyncWorker
 
                     if (name_value.valid())
                     {
-                        properties.emplace_back("name_local", name_value);
+                        std::string preserved_key = baton_data_->language_property + "_local";
+                        properties.emplace_back(preserved_key, name_value);
 
                         if (!name_was_set)
                         {
-                            properties.emplace_back("name", name_value);
+                            properties.emplace_back(baton_data_->language_property, name_value);
                         }
                     }
 
@@ -844,7 +850,8 @@ Napi::Value localize(Napi::CallbackInfo const& info)
     Napi::Value params_val = info[0];
     Napi::Buffer<char> buffer;
     std::string language;
-    bool change_names = true;
+    std::string language_property = "name";
+    std::string language_prefix = "_mbx_";
     std::vector<std::string> worldviews;
     std::string worldview_property = "_mbx_worldview";
     bool compress = false;
@@ -889,14 +896,28 @@ Napi::Value localize(Napi::CallbackInfo const& info)
                 return utils::CallbackError("params.language cannot be an empty string", info);
             }
         }
-        if (language_val.IsNull() || language_val.IsUndefined())
-        {
-            change_names = false;
-        }
     }
-    else
+
+    // params.language_property (optional)
+    if (params.Has(Napi::String::New(info.Env(), "language_property")))
     {
-        change_names = false;
+        Napi::Value language_property_val = params.Get(Napi::String::New(info.Env(), "language_property"));
+        if (!language_property_val.IsString())
+        {
+            return utils::CallbackError("params.language_property must be a string", info);
+        }
+        language_property = language_property_val.As<Napi::String>();
+    }
+
+    // params.language_prefix (optional)
+    if (params.Has(Napi::String::New(info.Env(), "language_prefix")))
+    {
+        Napi::Value language_prefix_val = params.Get(Napi::String::New(info.Env(), "language_prefix"));
+        if (!language_prefix_val.IsString())
+        {
+            return utils::CallbackError("params.language_prefix must be a string", info);
+        }
+        language_prefix = language_prefix_val.As<Napi::String>();
     }
 
     // params.worldview
@@ -948,7 +969,15 @@ Napi::Value localize(Napi::CallbackInfo const& info)
         compress = comp_value.As<Napi::Boolean>().Value();
     }
 
-    std::unique_ptr<LocalizeBatonType> baton_data = std::make_unique<LocalizeBatonType>(buffer, language, change_names, worldviews, worldview_property, compress);
+    std::unique_ptr<LocalizeBatonType> baton_data = std::make_unique<LocalizeBatonType>(
+        buffer,
+        language,
+        language_property,
+        language_prefix,
+        worldviews,
+        worldview_property,
+        compress
+    );
 
     auto* worker = new LocalizeWorker{std::move(baton_data), callback};
     worker->Queue();

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -976,8 +976,7 @@ Napi::Value localize(Napi::CallbackInfo const& info)
         language_prefix,
         worldviews,
         worldview_property,
-        compress
-    );
+        compress);
 
     auto* worker = new LocalizeWorker{std::move(baton_data), callback};
     worker->Queue();

--- a/test/vtcomposite-localize-language.test.js
+++ b/test/vtcomposite-localize-language.test.js
@@ -300,3 +300,50 @@ test('[localize] success - no language specified', (assert) => {
     assert.end();
   });
 });
+
+test('[localize language] custom params.language_property and params.language_prefix properties', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'places',
+          features: [
+            {
+              id: 10,
+              tags: [
+                0, 0, // language: hello
+                1, 1, // _drop_me_language_jp: kon'nichiwa
+                2, 2  // language_es: hola
+              ],
+              type: 1, // point
+              geometry: [ 9, 54, 38 ]
+            }
+          ],
+          keys: [ 'language', '_drop_me_language_jp', 'language_es' ],
+          values: [
+            { string_value: 'hello' },
+            { string_value: 'kon\'nichiwa' },
+            { string_value: 'hola' }
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    language: 'jp',
+    language_property: 'language',
+    language_prefix: '_drop_me_'
+  };
+
+  localize(params, (err, buffer) => {
+    assert.notOk(err);
+    const info = vtinfo(buffer);
+    assert.equal(info.layers.places.length, 1, 'expected number of features');
+    assert.deepEqual(info.layers.places.feature(0).properties, {
+      language: 'kon\'nichiwa',
+      language_es: 'hola',
+      language_local: 'hello'
+    }, 'expected properties');
+    assert.end();
+  });
+});

--- a/test/vtcomposite-param-validation.test.js
+++ b/test/vtcomposite-param-validation.test.js
@@ -602,6 +602,50 @@ test('[localize] params.language', (assert) => {
   assert.end();
 });
 
+test('[localize] params.language_property', (assert) => {
+  localize({
+    buffer: Buffer.from('howdy'),
+    language: 'es',
+    language_property: 1 // not a string
+  }, function (err) {
+    assert.ok(err);
+    assert.equal(err.message, 'params.language_property must be a string', 'expected error message');
+  });
+
+  localize({
+    buffer: Buffer.from('howdy'),
+    language: 'es',
+    language_property: null // null value
+  }, function (err) {
+    assert.ok(err);
+    assert.equal(err.message, 'params.language_property must be a string', 'expected error message');
+  });
+
+  assert.end();
+});
+
+test('[localize] params.language_property', (assert) => {
+  localize({
+    buffer: Buffer.from('howdy'),
+    language: 'es',
+    language_prefix: 1 // not a string
+  }, function (err) {
+    assert.ok(err);
+    assert.equal(err.message, 'params.language_prefix must be a string', 'expected error message');
+  });
+
+  localize({
+    buffer: Buffer.from('howdy'),
+    language: 'es',
+    language_prefix: null // null value
+  }, function (err) {
+    assert.ok(err);
+    assert.equal(err.message, 'params.language_prefix must be a string', 'expected error message');
+  });
+
+  assert.end();
+});
+
 test('[localize] params.worldviews', (assert) => {
   localize({
     buffer: Buffer.from('howdy'),

--- a/test/vtcomposite-param-validation.test.js
+++ b/test/vtcomposite-param-validation.test.js
@@ -624,7 +624,7 @@ test('[localize] params.language_property', (assert) => {
   assert.end();
 });
 
-test('[localize] params.language_property', (assert) => {
+test('[localize] params.language_prefix', (assert) => {
   localize({
     buffer: Buffer.from('howdy'),
     language: 'es',


### PR DESCRIPTION
Sibling to #123 - this allows the user to set custom values for properties pertaining to language localization. 

### What changed?

* updated API pertaining to language options
  * `language` - remains the same
  * `language_property` - set the primary property used to distinguish language and hold translations within the vector tile features. Default is "name". Will find translations from properties with keys like `{language_property}_{language}`, example: `name_jp`. 
  * `language_prefix` - set the secondary properties used for storing additional translations. Any properties found with the prefix are dropped before the tile is returned. Will find translations from properties with keys like `{language_prefix}{language_property}_{language}`, example: `_mbx_name_jp`.
* removed `change_names` boolean passed from the N-API context to C++ in favor of `baton_data_->language.empty()` https://github.com/mapbox/vtcomposite/pull/123#discussion_r912194254 (and removed previous `||` operator https://github.com/mapbox/vtcomposite/pull/123#discussion_r912210315)

API:

```js
const params = {
  buffer: tile,
  language: 'es',
  language_property: 'name',
  language_prefix: '_mbx_'
};

localize(params, cb);
```

