### PR TITLE
1.1.0 - class property translation in localization logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.0
+
+- Updates the `localize` function to translate `_mbx_class` to `class` when `_mbx_worldview` is provided along with matching worldview filtering
+
+
 # 1.0.0
 
 **BREAKING** Module now returns an object with two functions [#127](https://github.com/mapbox/vtcomposite/pull/127)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ A filtering function for modifying a tile's features and properties to support l
     - If a feature does not have a `params.worldview_property` property it is retained.
   - `params.worldview_property` **String** the name of the property that specifies in which worldview a feature belongs. The vector tile encoded property must contain a comma-separated string of ISO 3166-1 alpha-2 country codes that define which worldviews the feature represents (example: `US,RU,IN`). Default value: `_mbx_worldview`.
     - If a feature contains multiple values that match multiple given values in the `params.worldview` array, it will be split into multiple features in the final vector tile, one for each matching worldview.
+  - `params.class_property` **String** the name of the property that specifies the class of a feature (examples: `sea`, `canal`, `village`). Default value: `_mbx_class`.
 - `callback` **Function** callback function that returns `err` and `buffer` parameters
 
 #### Example
@@ -105,6 +106,7 @@ const params = {
   language: null,
   worldview: [],
   worldview_property: '_mbx_worldview',
+  class_property: '_mbx_class',
   compress: true
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "1.1.0-dev2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "1.0.0",
+  "version": "1.1.0-dev2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "1.0.0",
+  "version": "1.1.0-dev",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "1.1.0-dev",
+  "version": "1.1.0-dev0",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "1.1.0-dev2",
+  "version": "1.1.0",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "1.1.0-dev0",
+  "version": "1.1.0-dev2",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -713,7 +713,8 @@ struct LocalizeWorker : Napi::AsyncWorker
                             continue;
                         }
 
-                        if (property_key == baton_data_->class_property){
+                        if (property_key == baton_data_->class_property)
+                        {
                             if (property.value().type() == vtzero::property_value_type::string_value)
                             {
                                 class_value = property.value();

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -782,11 +782,14 @@ struct LocalizeWorker : Napi::AsyncWorker
                     }
                     else
                     {
+                        if (class_value.valid() && name_was_set)
+                        {
+                            properties.emplace_back("class", class_value);
+                        }
                         build_localized_feature(feature, properties, "", lbuilder);
                     }
                 }
             }
-
             std::string& tile_buffer = *output_buffer_;
             if (baton_data_->compress)
             {

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -100,6 +100,7 @@ struct LocalizeBatonType
                       std::string language_prefix_,
                       std::vector<std::string> worldviews_,
                       std::string worldview_property_,
+                      std::string class_property_,
                       bool compress_)
         : data{buffer.Data(), buffer.Length()},
           buffer_ref{Napi::Persistent(buffer)},
@@ -108,6 +109,7 @@ struct LocalizeBatonType
           language_prefix{std::move(language_prefix_)},
           worldviews{std::move(worldviews_)},
           worldview_property{std::move(worldview_property_)},
+          class_property{std::move(class_property_)},
           compress{compress_}
     {
     }
@@ -137,6 +139,7 @@ struct LocalizeBatonType
     std::string language_prefix;
     std::vector<std::string> worldviews;
     std::string worldview_property;
+    std::string class_property;
     bool compress;
 };
 
@@ -693,7 +696,7 @@ struct LocalizeWorker : Napi::AsyncWorker
                     bool has_worldview_key = false;
                     bool name_was_set = false;
                     vtzero::property_value name_value;
-
+                    vtzero::property_value class_value;
                     // accumulate final properties (except _mbx_worldview translation to worldview) here
                     std::vector<std::pair<std::string, vtzero::property_value>> properties;
                     while (auto property = feature.next_property())
@@ -707,6 +710,14 @@ struct LocalizeWorker : Napi::AsyncWorker
                                 worldviews_to_create = worldviews_for_feature(static_cast<std::string>(property.value().string_value()));
                             }
 
+                            continue;
+                        }
+
+                        if (property_key == baton_data_->class_property){
+                            if (property.value().type() == vtzero::property_value_type::string_value)
+                            {
+                                class_value = property.value();
+                            }
                             continue;
                         }
 
@@ -759,6 +770,10 @@ struct LocalizeWorker : Napi::AsyncWorker
 
                     if (has_worldview_key)
                     {
+                        if (class_value.valid())
+                        {
+                            properties.emplace_back("class", class_value);
+                        }
                         for (auto const& wv : worldviews_to_create)
                         {
                             build_localized_feature(feature, properties, wv, lbuilder);
@@ -854,6 +869,7 @@ Napi::Value localize(Napi::CallbackInfo const& info)
     std::string language_prefix = "_mbx_";
     std::vector<std::string> worldviews;
     std::string worldview_property = "_mbx_worldview";
+    std::string class_property = "_mbx_class";
     bool compress = false;
     if (!params_val.IsObject())
     {
@@ -958,6 +974,17 @@ Napi::Value localize(Napi::CallbackInfo const& info)
         worldview_property = worldview_property_val.As<Napi::String>();
     }
 
+    // params.class_property
+    if (params.Has(Napi::String::New(info.Env(), "class_property")))
+    {
+        Napi::Value class_property_val = params.Get(Napi::String::New(info.Env(), "class_property"));
+        if (!class_property_val.IsString())
+        {
+            return utils::CallbackError("params.class_property must be a string", info);
+        }
+        class_property = class_property_val.As<Napi::String>();
+    }
+
     // params.compress
     if (params.Has(Napi::String::New(info.Env(), "compress")))
     {
@@ -976,6 +1003,7 @@ Napi::Value localize(Napi::CallbackInfo const& info)
         language_prefix,
         worldviews,
         worldview_property,
+        class_property,
         compress);
 
     auto* worker = new LocalizeWorker{std::move(baton_data), callback};

--- a/test/vtcomposite-localize-class.test.js
+++ b/test/vtcomposite-localize-class.test.js
@@ -1,0 +1,219 @@
+'use strict';
+
+const localize = require('../lib/index.js').localize;
+const { vtinfo } = require('./test-utils.js');
+const mvtFixtures = require('@mapbox/mvt-fixtures');
+const test = require('tape');
+
+test('[localize class] _mbx_class is assigned to class when worldview filtering is provided', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'admin',
+          features: [
+            {
+              id: 10,
+              tags: [
+                0, 0, // _mbx_worldview
+                1, 1  // _mbx_class
+              ],
+              type: 1, // point
+              geometry: [ 9, 55, 38 ]
+            }
+          ],
+          keys: [ '_mbx_worldview', '_mbx_class' ],
+          values: [
+            { string_value: 'US' },
+            { string_value: 'affogato' },
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    worldviews: ['US']
+  };
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, {
+      worldview: 'US',
+      class: 'affogato'
+    }, 'expected properties');
+    assert.end();
+  });
+});
+
+test('[localize worldview] _mbx_class is assigned to class when worldview is `all`', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'admin',
+          features: [
+            {
+              id: 10,
+              tags: [
+                0, 0, // _mbx_worldview
+                1, 1  // _mbx_class
+              ],
+              type: 1, // point
+              geometry: [9, 54, 38]
+            }
+          ],
+          keys: ['_mbx_worldview', '_mbx_class'],
+          values: [
+            { string_value: 'all' },
+            { string_value: 'affogato' }
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    worldviews: []
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, {
+      worldview: 'all',
+      class: 'affogato'
+    });
+    assert.end();
+  });
+});
+
+test('[localize class] _mbx_class is assigned to class when multiple worldviews are provided', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'admin',
+          features: [
+            {
+              id: 10,
+              tags: [
+                0, 0, // _mbx_worldview
+                1, 1  // _mbx_class
+              ],
+              type: 1, // point
+              geometry: [ 9, 55, 38 ]
+            }
+          ],
+          keys: [ '_mbx_worldview', '_mbx_class' ],
+          values: [
+            { string_value: 'US,CN' },
+            { string_value: 'affogato' }
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    worldviews: ['US', 'CN'],
+  };
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, {
+      worldview: 'CN',
+      class: 'affogato'
+    }, 'expected properties');
+    assert.deepEqual(tile.layers.admin.feature(1).properties, {
+      worldview: 'US',
+      class: 'affogato'
+    }, 'expected properties');
+    assert.end();
+  });
+});
+
+test('[localize class] _mbx_class is dropped with no worldview filtering', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'admin',
+          features: [
+            {
+              id: 10,
+              tags: [ 0, 0 ], // _mbx_worldview
+              type: 1, // point
+              geometry: [ 9, 54, 38 ]
+            },
+            {
+              id: 11,
+              tags: [ 1, 1 ], // _mbx_class
+              type: 1, // point
+              geometry: [ 9, 55, 38 ]
+            }
+          ],
+          keys: [ '_mbx_worldview', '_mbx_class' ],
+          values: [
+            { string_value: 'US' },
+            { string_value: 'affogato' },
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    worldviews: []
+  };
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, {}, 'expected properties');
+    assert.end();
+  });
+});
+
+test('[localize class] Invalid _mbx_class value should be dropped', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'admin',
+          features: [
+            {
+              id: 10,
+              tags: [
+                0, 0, // _mbx_worldview
+                1, 1  // _mbx_class
+              ],
+              type: 1, // point
+              geometry: [ 9, 55, 38 ]
+            }
+          ],
+          keys: [ '_mbx_worldview', '_mbx_class' ],
+          values: [
+            { string_value: 'US' },
+            { int_value: 42 },
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    worldviews: ['US']
+  };
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, {
+      worldview: 'US',
+    }, 'expected properties');
+    assert.end();
+  });
+});

--- a/test/vtcomposite-localize-class.test.js
+++ b/test/vtcomposite-localize-class.test.js
@@ -177,6 +177,50 @@ test('[localize class] _mbx_class is dropped with no worldview filtering', (asse
   });
 });
 
+test('[localize class] _mbx_class is assigned to class when language is provided and there is no worldview filtering', (assert) => {
+  const params = {
+    buffer: mvtFixtures.create({
+      layers: [
+        {
+          version: 2,
+          name: 'admin',
+          features: [
+            {
+              id: 10,
+              tags: [
+                0, 0, // name
+                1, 1, // _mbx_name_de
+                2, 2,  // _mbx_class
+              ],
+              type: 1, // point
+              geometry: [ 9, 54, 38 ]
+            }
+          ],
+          keys: [ 'name', '_mbx_name_de', '_mbx_class' ],
+          values: [
+            { string_value: 'France' },
+            { string_value: 'Frankreich' },
+            { string_value: 'affogato' },
+          ],
+          extent: 4096
+        }
+      ]
+    }).buffer,
+    language: 'de',
+  };
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, {
+      name: 'Frankreich',
+      name_local: 'France',
+      class: 'affogato'
+    }, 'expected properties');
+    assert.end();
+  });
+});
+
 test('[localize class] Invalid _mbx_class value should be dropped', (assert) => {
   const params = {
     buffer: mvtFixtures.create({


### PR DESCRIPTION
This work updates localization logic to perform translation on the `_mbx_class` property.