### PR TITLE
param.languages and param.worldviews can be empty lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+- Fixes a bug in `localize` function that throws an error when languages or worldviews is an empty array [#131](https://github.com/mapbox/vtcomposite/pull/131)
+
 # 2.0.0
 
 - Updates the `localize` function to return features with either all properties localized or features with no properties localized; nothing in between [#129](https://github.com/mapbox/vtcomposite/pull/129).

--- a/README.md
+++ b/README.md
@@ -79,14 +79,14 @@ A filtering function for modifying a tile's features and properties to support l
   - `params.hidden_prefix` **String** prefix for any additional properties that will be used to override non-prefixed properties.
     - Default value: `_mbx_`.
     - Any property that starts with this prefix are considered hidden properties and thus will be dropped.
-  - `params.languages` **Array<String>** array of IETF BCP 47 language codes used to search for matching translations available in a feature's properties.
+  - `params.languages` **Array<Optional<String>>** array of IETF BCP 47 language codes used to search for matching translations available in a feature's properties.
     - Optional parameter.
     - All language-related properties must match the following format: `{hidden_prefix}{language_property}_{language}`.
     - Default properties are `_mbx_name_{language}`; for example, the `_mbx_name_jp` property contains the Japanese translation for the value in `name`.
   - `params.language_property` **String** the primary property in features that identifies the feature in a language.
     - Default value: `name`.
     - This values is used to search for additional translations that match the following format `{language_property}_{language}`.
-  - `params.worldviews` **Array<String>** array of ISO 3166-1 alpha-2 country codes used to filter out features of different worldviews.
+  - `params.worldviews` **Array<Optional<String>>** array of ISO 3166-1 alpha-2 country codes used to filter out features of different worldviews.
     - Optional parameter.
     - For now, only the first item in the array will be processed; the rest are discarded (*TODO in the future*: expand support for more than one worldviews).
   - `params.worldview_property` **String** the name of the property that specifies in which worldview a feature belongs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.0.1",
+  "version": "2.0.1-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.0.1-dev",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "1.1.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.0.1",
+  "version": "2.0.1-dev",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.0.1-dev",
+  "version": "2.0.1",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -1035,33 +1035,25 @@ Napi::Value localize(Napi::CallbackInfo const& info)
         Napi::Value language_val = params.Get(Napi::String::New(info.Env(), "languages"));
         if (language_val.IsArray())
         {
+            return_localized_tile = true;
+
             Napi::Array language_array = language_val.As<Napi::Array>();
             std::uint32_t num_languages = language_array.Length();
 
-            if (num_languages > 0)
+            for (std::uint32_t lg = 0; lg < num_languages; ++lg)
             {
-                languages.reserve(num_languages);
-
-                for (std::uint32_t lg = 0; lg < num_languages; ++lg)
+                Napi::Value language_item_val = language_array.Get(lg);
+                if (!language_item_val.IsString() || language_item_val == empty_string)
                 {
-                    Napi::Value language_item_val = language_array.Get(lg);
-                    if (!language_item_val.IsString() || language_item_val == empty_string)
-                    {
-                        return utils::CallbackError("params.languages must be an array of non-empty strings", info);
-                    }
-                    std::string language_item = language_item_val.As<Napi::String>();
-                    languages.push_back(language_item);
+                    return utils::CallbackError("params.languages must be an array of non-empty strings", info);
                 }
-                return_localized_tile = true;
-            }
-            else
-            {
-                return utils::CallbackError("params.languages must be a non-empty array", info);
+                std::string language_item = language_item_val.As<Napi::String>();
+                languages.push_back(language_item);
             }
         }
         else
         {
-            return utils::CallbackError("params.languages must be a non-empty array", info);
+            return utils::CallbackError("params.languages must be an array", info);
         }
     }
 
@@ -1087,33 +1079,25 @@ Napi::Value localize(Napi::CallbackInfo const& info)
         Napi::Value worldview_val = params.Get(Napi::String::New(info.Env(), "worldviews"));
         if (worldview_val.IsArray())
         {
+            return_localized_tile = true;
+
             Napi::Array worldview_array = worldview_val.As<Napi::Array>();
             std::uint32_t num_worldviews = worldview_array.Length();
 
-            if (num_worldviews > 0)
+            for (std::uint32_t wv = 0; wv < num_worldviews; ++wv)
             {
-                worldviews.reserve(num_worldviews);
-
-                for (std::uint32_t wv = 0; wv < num_worldviews; ++wv)
+                Napi::Value worldview_item_val = worldview_array.Get(wv);
+                if (!worldview_item_val.IsString() || worldview_item_val == empty_string)
                 {
-                    Napi::Value worldview_item_val = worldview_array.Get(wv);
-                    if (!worldview_item_val.IsString() || worldview_item_val == empty_string)
-                    {
-                        return utils::CallbackError("params.worldviews must be an array of non-empty strings", info);
-                    }
-                    std::string worldview_item = worldview_item_val.As<Napi::String>();
-                    worldviews.push_back(worldview_item);
+                    return utils::CallbackError("params.worldviews must be an array of non-empty strings", info);
                 }
-                return_localized_tile = true;
-            }
-            else
-            {
-                return utils::CallbackError("params.worldviews must be a non-empty array", info);
+                std::string worldview_item = worldview_item_val.As<Napi::String>();
+                worldviews.push_back(worldview_item);
             }
         }
         else
         {
-            return utils::CallbackError("params.worldviews must be a non-empty array", info);
+            return utils::CallbackError("params.worldviews must be an array", info);
         }
     }
 

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -1040,6 +1040,8 @@ Napi::Value localize(Napi::CallbackInfo const& info)
             Napi::Array language_array = language_val.As<Napi::Array>();
             std::uint32_t num_languages = language_array.Length();
 
+            languages.reserve(num_languages);
+
             for (std::uint32_t lg = 0; lg < num_languages; ++lg)
             {
                 Napi::Value language_item_val = language_array.Get(lg);
@@ -1083,6 +1085,10 @@ Napi::Value localize(Napi::CallbackInfo const& info)
 
             Napi::Array worldview_array = worldview_val.As<Napi::Array>();
             std::uint32_t num_worldviews = worldview_array.Length();
+
+            // will put params.worldview_default into worldviews if params.worldviews is empty
+            // hence reserving minimum 1 slot
+            worldviews.reserve(num_worldviews > 0 ? num_worldviews : 1);
 
             for (std::uint32_t wv = 0; wv < num_worldviews; ++wv)
             {

--- a/test/vtcomposite-localize-language.test.js
+++ b/test/vtcomposite-localize-language.test.js
@@ -245,6 +245,53 @@ test('[localize] success - _mbx prefixed property keys removed from all layers',
   });
 });
 
+test('[localize] success - languages is an empty list and no worldview specified (i.e. still returns localized)', (assert) => {
+  const initialBuffer = mvtFixtures.get('063').buffer;
+  const topLayerKeys = ['population'];
+  const bottomLayerKeys = [
+    'name',
+    'name_en',
+    'name_fr',
+    '_mbx_name_fr',
+    '_mbx_name_de',
+    '_mbx_other',
+    'population'
+  ];
+  const topLayerKeysExpected = topLayerKeys;
+  const bottomLayerKeysExpected = ['name', 'name_local', 'population'];
+
+  const localizedProperties0 = {
+    name: 'Germany',
+    name_local: 'Germany'
+  };
+  const localizedProperties1 = {
+    name: 'Espana',
+    name_local: 'Espana',
+    population: 20
+  };
+
+  const initialOutputInfo = vtinfo(initialBuffer);
+  assert.deepEqual(initialOutputInfo.layers.top._keys, topLayerKeys, 'expected initial keys');
+  assert.deepEqual(initialOutputInfo.layers.bottom._keys, bottomLayerKeys, 'expected initial keys');
+
+  const params = {
+    buffer: initialBuffer,
+    languages: []
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.notOk(err);
+    const outputInfo = vtinfo(vtBuffer);
+    const localizedFeature0 = outputInfo.layers.bottom.feature(0);
+    const localizedFeature1 = outputInfo.layers.bottom.feature(1);
+    assert.deepEqual(localizedFeature0.properties, localizedProperties0, 'expected same name, dropped _mbx_name_* properties');
+    assert.deepEqual(localizedFeature1.properties, localizedProperties1, 'expected same name, dropped _mbx_name_* properties');
+    assert.deepEqual(outputInfo.layers.top._keys, topLayerKeysExpected, 'expected same keys');
+    assert.deepEqual(outputInfo.layers.bottom._keys, bottomLayerKeysExpected, 'expected dropped _mbx_name_* keys');
+    assert.end();
+  });
+});
+
 test('[localize] success - no language specified but has worldview specified (i.e. return localized features)', (assert) => {
   const initialBuffer = mvtFixtures.get('063').buffer;
   const topLayerKeys = ['population'];

--- a/test/vtcomposite-localize-param-validation.test.js
+++ b/test/vtcomposite-localize-param-validation.test.js
@@ -120,7 +120,7 @@ test('[localize] params.languages', (assert) => {
     languages: undefined
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.languages must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.languages must be an array', 'expected error message');
   });
 
   localize({
@@ -128,7 +128,7 @@ test('[localize] params.languages', (assert) => {
     languages: null
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.languages must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.languages must be an array', 'expected error message');
   });
 
   localize({
@@ -136,7 +136,7 @@ test('[localize] params.languages', (assert) => {
     languages: 1
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.languages must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.languages must be an array', 'expected error message');
   });
 
   localize({
@@ -144,7 +144,7 @@ test('[localize] params.languages', (assert) => {
     languages: '' // empty string
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.languages must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.languages must be an array', 'expected error message');
   });
 
   localize({
@@ -152,15 +152,14 @@ test('[localize] params.languages', (assert) => {
     languages: 'hi'
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.languages must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.languages must be an array', 'expected error message');
   });
 
   localize({
-    buffer: Buffer.from('hi'),
+    buffer: mvtFixtures.get('064').buffer,
     languages: []
   }, (err) => {
-    assert.ok(err);
-    assert.equal(err.message, 'params.languages must be a non-empty array', 'expected error message');
+    assert.ifError(err);  // [] is valid; should not have any error
   });
 
   localize({
@@ -244,7 +243,7 @@ test('[localize] params.worldviews', (assert) => {
     worldviews: null
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.worldviews must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.worldviews must be an array', 'expected error message');
   });
 
   localize({
@@ -252,7 +251,7 @@ test('[localize] params.worldviews', (assert) => {
     worldviews: undefined
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.worldviews must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.worldviews must be an array', 'expected error message');
   });
 
   localize({
@@ -260,7 +259,7 @@ test('[localize] params.worldviews', (assert) => {
     worldviews: 1 // not an array
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.worldviews must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.worldviews must be an array', 'expected error message');
   });
 
   localize({
@@ -268,7 +267,7 @@ test('[localize] params.worldviews', (assert) => {
     worldviews: ''
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.worldviews must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.worldviews must be an array', 'expected error message');
   });
 
   localize({
@@ -276,15 +275,14 @@ test('[localize] params.worldviews', (assert) => {
     worldviews: 'US'
   }, (err) => {
     assert.ok(err);
-    assert.equal(err.message, 'params.worldviews must be a non-empty array', 'expected error message');
+    assert.equal(err.message, 'params.worldviews must be an array', 'expected error message');
   });
 
   localize({
-    buffer: Buffer.from('howdy'),
+    buffer: mvtFixtures.get('064').buffer,
     worldviews: []
   }, (err) => {
-    assert.ok(err);
-    assert.equal(err.message, 'params.worldviews must be a non-empty array', 'expected error message');
+    assert.ifError(err);  // [] is valid; should not have any error
   });
 
   localize({

--- a/test/vtcomposite-localize-worldview.test.js
+++ b/test/vtcomposite-localize-worldview.test.js
@@ -471,6 +471,44 @@ test('[localize worldview] requesting localized worldview; feature with no world
   });
 });
 
+test('[localize worldview] worldviews is an empty list; feature with compatible worldview key in the default worldview', (assert) => {
+  const feature = mvtFixtures.create({
+    layers: [
+      {
+        version: 2,
+        name: 'admin',
+        features: [
+          {
+            id: 10,
+            tags: [0, 0],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          }
+        ],
+        keys: ['_mbx_worldview'],
+        values: [
+          { string_value: 'CN,JP,TR,US' }  // contains the default worldview which is US
+        ],
+        extent: 4096
+      }
+    ]
+  }).buffer;
+
+  const params = {
+    buffer: feature,
+    worldviews: []
+    // default worldview is US
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, { worldview: 'US' }, 'expected properties');
+    assert.end();
+  });
+});
 
 /** ****************************************************************************
  * TEST SET 3:


### PR DESCRIPTION
This PR fixes a bug that rejects empty languages and worldview lists.