### PR TITLE
Support languages="all" parameter in localize function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 dist: bionic
 
+node_js: 16
+
 # enable c++11/14 builds
 addons:
   apt:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+
+- Add language code "all" [#136](https://github.com/mapbox/vtcomposite/pull/136)
+
 # 2.1.0
 
 - Add language code "local" [#133](https://github.com/mapbox/vtcomposite/pull/133)

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ A filtering function for modifying a tile's features and properties to support l
       - The script of `{language_property}`, if available, must be stored in the `{language_property}_script` property.
       - If `{language_property}_script` not in the `params.omit_scripts` list, use `{language_property}` when searching for matching translation.
       - If `{language_property}_script` is in the `params.omit_scripts` list, skip `{language_property}` when searching for matching translation.
+    - `all` language code returns `{language_property}`, `{language_property}_local` and all possible language properties that have different values than `{language_property}`
   - `params.omit_scripts` **Array<Optional<String>>** array of scripts to skip `local` language code.
   - `params.language_property` **String** the primary property in features that identifies the feature in a language.
     - Default value: `name`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev5",
+  "version": "2.2.0-dev6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev5",
+      "version": "2.2.0-dev6",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev2",
+  "version": "2.2.0-dev3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev2",
+      "version": "2.2.0-dev3",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev6",
+  "version": "2.2.0-dev7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev6",
+      "version": "2.2.0-dev7",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev4",
+  "version": "2.2.0-dev5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev4",
+      "version": "2.2.0-dev5",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev10",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev10",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev7",
+  "version": "2.2.0-dev9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev7",
+      "version": "2.2.0-dev9",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0",
+  "version": "2.2.0-rc1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0",
+      "version": "2.2.0-rc1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -3143,7 +3143,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "agent-base": {
       "version": "6.0.2",
@@ -3631,7 +3632,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.1.1",
@@ -4642,6 +4644,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4683,14 +4693,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0-i18n-dev1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-rc1",
+      "version": "2.2.0-i18n-dev1",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev9",
+  "version": "2.2.0-dev10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev9",
+      "version": "2.2.0-dev10",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-i18n-dev1",
+  "version": "2.2.0-dev2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-i18n-dev1",
+      "version": "2.2.0-dev2",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev3",
+  "version": "2.2.0-dev4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0-dev3",
+      "version": "2.2.0-dev4",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev2",
+  "version": "2.2.0-dev3",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev5",
+  "version": "2.2.0-dev6",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev10",
+  "version": "2.2.0",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev7",
+  "version": "2.2.0-dev9",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev3",
+  "version": "2.2.0-dev4",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev4",
+  "version": "2.2.0-dev5",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-i18n-dev1",
+  "version": "2.2.0-dev2",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev9",
+  "version": "2.2.0-dev10",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0",
+  "version": "2.2.0-rc1",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-dev6",
+  "version": "2.2.0-dev7",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0-rc1",
+  "version": "2.2.0-i18n-dev1",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -19,8 +19,8 @@
 // stl
 #include <algorithm>
 #include <string>
-#include <utility>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace vtile {
@@ -981,7 +981,8 @@ struct LocalizeWorker : Napi::AsyncWorker
                             std::string language_property_key = language_property.first;
                             vtzero::property_value language_property_value = language_property.second;
 
-                            if (language_property_value.string_value() != original_language_value.string_value()) {
+                            if (language_property_value.string_value() != original_language_value.string_value())
+                            {
                                 final_properties.emplace_back(language_property_key, language_property_value);
                             }
                         }

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -947,6 +947,8 @@ struct LocalizeWorker : Napi::AsyncWorker
                                 language_property_final_value = language_value;
                             }
 
+                            std::unordered_map<std::string, bool> added_languages;
+
                             for (size_t i = 0; i < property_languages.size(); ++i) {
                                 std::string language_key = property_languages[i].first;
                                 std::string language_value = property_languages[i].second;
@@ -955,7 +957,13 @@ struct LocalizeWorker : Napi::AsyncWorker
                                     continue;
                                 }
 
+                                // if current languages was already added to final properties skips it
+                                if (added_languages.find(language_key) != hashmap.end()) {
+                                    continue;
+                                }
+
                                 final_properties.emplace_back(language_key, language_value);
+                                added_languages[language_key] = true;
                             }
                         }
                     }

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -850,7 +850,6 @@ struct LocalizeWorker : Napi::AsyncWorker
                                 );
                             }
 
-                            // it's a langauge property
                             // check if the property is of higher precedence that language key encountered so far
                             std::uint32_t idx = static_cast<std::uint32_t>(std::distance(language_key_precedence.begin(), std::find(language_key_precedence.begin(), language_key_precedence.end(), property_key)));
                             if (idx < language_key_idx)
@@ -880,7 +879,7 @@ struct LocalizeWorker : Napi::AsyncWorker
                                 }
                             }
                             else
-                            {                                // @todo add the logic to add the extra languages
+                            {
                                 if (keep_every_language)
                                 {
                                     if (!utils::startswith(property_key, baton_data_->hidden_prefix))

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -20,8 +20,8 @@
 #include <algorithm>
 #include <string>
 #include <utility>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 namespace vtile {
 
@@ -653,7 +653,7 @@ struct LocalizeWorker : Napi::AsyncWorker
         return matching_worldviews;
     }
 
-    static std::string remove_hidden_prefix(std::string property_key, std::string hidden_prefix)
+    static std::string remove_hidden_prefix(std::string property_key, std::string& hidden_prefix)
     {
         bool has_hidden_prefix = utils::startswith(property_key, hidden_prefix);
 
@@ -981,8 +981,9 @@ struct LocalizeWorker : Napi::AsyncWorker
                             std::string language_property_key = language_property.first;
                             vtzero::property_value language_property_value = language_property.second;
 
-                            if (language_property_value.string_value() != original_language_value.string_value())
+                            if (language_property_value.string_value() != original_language_value.string_value()) {
                                 final_properties.emplace_back(language_property_key, language_property_value);
+                            }
                         }
                     }
 

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -948,14 +948,14 @@ struct LocalizeWorker : Napi::AsyncWorker
                             }
 
                             for (size_t i = 0; i < property_languages.size(); ++i) {
-                                std::string langauge_key = roperty_languages[i].first;
-                                std::string langauge_value = roperty_languages[i].second;
+                                std::string language_key = property_languages[i].first;
+                                std::string language_value = property_languages[i].second;
 
-                                if (langauge_value == original_language_value) {
+                                if (language_value == original_language_value) {
                                     continue;
                                 }
 
-                                final_properties.emplace_back(langauge_key, langauge_value);
+                                final_properties.emplace_back(language_key, language_value);
                             }
                         }
                     }

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -974,7 +974,7 @@ struct LocalizeWorker : Napi::AsyncWorker
 
                     // Check the list of languages to be added
                     // Only add the ones that are different from original local language to the final properties
-                    if (is_international_tile_with_all_languages && original_language_value.valid())
+                    if (is_international_tile_with_all_languages)
                     {
                         for (const auto& language_property : language_properties_to_be_added_to_final_properties)
                         {

--- a/test/vtcomposite-localize-language.test.js
+++ b/test/vtcomposite-localize-language.test.js
@@ -861,7 +861,7 @@ test('[localize language] _mbx_name_local exists in the input tile', (assert) =>
   });
 });
 
-test('[localize language] languages=all returns name, name_local and all name_xx(s) with _mbx_ dropped removed from property name', (assert) => {
+test('[localize language] languages=all returns name, name_local and all name_xx(s) with _mbx_ removed from property name', (assert) => {
   const rawDataLanguageProperties = {
     name: '你好',
     name_script: 'Han',


### PR DESCRIPTION
This PR handles `languages=all` param for `localize` function. 

Summary of changes:
- [x] Handle `languages=all`: returns original language name and all languages that:
  - [x] are different than original language name
  - [x] have `hidden_prefix` omitted from the property name
- [x] Rename `keep_every_language` to `keep_all_non_hidden_languages` for clarity

Expected Result:

```
name -> raw.name
name_local -> raw.name
name_xx -> (raw.name_xx || raw.{hidden_prefix}_name_xx) && (name_xx != name)
```

Logic flow:

```
For each layer:
  For each feature:

    * For each property:
        If language property:
          If param languages=[all]:
            If property name = 'name':
              - Add {name} to {final_properties}  
            Else:
              - Remove hidden_prefix (if needed) from property name
              - Set value for {name_xx} key in {language_properties_to_be_added_to_final_properties}
          Else:
            Process with current logic - no change
    --- End of property loop ---
   
    Add {name_local} = {name} to {final_properties}
   
    * For each {name_xx} key in {language_properties_to_be_added_to_final_properties}:
        If {name_xx} value != {name} value:
          - Add {name_xx} to {final_properties}
    
  --- End of feature loop ---
--- End of layer loop ---
     
```