### PR TITLE
Pin node version in travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 dist: bionic
 
+node_js: 16
+
 # enable c++11/14 builds
 addons:
   apt:


### PR DESCRIPTION
Previously Travis CI pipeline failed at installing node version from .nvmrc. This is fixed by specifying the node_js version in .travis.yml instead. 

Before:

```
Using nodejs version from .nvmrc
318.04s$ nvm install $(< .nvmrc)
Downloading and installing node v16.20.2...
Downloading https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz...
curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)
Binary download from https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz failed, trying source.
grep: /home/travis/.nvm/.cache/bin/node-v16.20.2-linux-x64/node-v16.20.2-linux-x64.tar.xz: No such file or directory
Provided file to checksum does not exist.
Binary download failed, trying source.
Detected that you have 2 CPU core(s)
Number of CPU core(s) less than or equal to 2, running in single-threaded mode
Clang v3.5+ detected! CC or CXX not specified, will use Clang as C/C++ compiler!
Downloading https://nodejs.org/dist/v16.20.2/node-v16.20.2.tar.xz...
curl: (92) HTTP/2 stream 1 was not closed cleanly: INTERNAL_ERROR (err 2)
Binary download from https://nodejs.org/dist/v16.20.2/node-v16.20.2.tar.xz failed, trying source.
grep: /home/travis/.nvm/.cache/src/node-v16.20.2/node-v16.20.2.tar.xz: No such file or directory
Provided file to checksum does not exist.
Failed to install 16. Remote repository may not be reachable.
`nvm install` failed
```

After:
```
$ nvm install 16
Downloading and installing node v16.20.2...
Downloading https://nodejs.org/dist/v16.20.2/node-v16.20.2-linux-x64.tar.xz...
Computing checksum with sha256sum
Checksums matched!
Now using node v16.20.2 (npm v8.19.4)
```
