### PR TITLE
Keep all worldviews as a comma separated list when specifying `worldviews=[ALL]`

### DIFF
--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -669,19 +669,24 @@ struct LocalizeWorker : Napi::AsyncWorker
     {
         try
         {
-            bool keep_every_worldview = true;
+            bool keep_all_non_hidden_worldviews = true;
             std::string incompatible_worldview_key;
             std::string compatible_worldview_key;
             std::vector<std::string> class_key_precedence;
             bool keep_all_non_hidden_languages = true;
             bool is_international_tile_with_all_languages = false;
+            bool is_international_tile_with_all_worldviews = false;
             std::vector<std::string> language_key_precedence;
 
             if (baton_data_->return_localized_tile)
             {
-                keep_every_worldview = false;
+                keep_all_non_hidden_worldviews = false;
                 incompatible_worldview_key = baton_data_->worldview_property;
                 compatible_worldview_key = baton_data_->hidden_prefix + baton_data_->worldview_property;
+                if (baton_data_->worldviews.size() == 1 && baton_data_->worldviews[0] == "ALL")
+                {
+                    is_international_tile_with_all_worldviews = true;
+                }
 
                 class_key_precedence.push_back(baton_data_->hidden_prefix + baton_data_->class_property);
                 class_key_precedence.push_back(baton_data_->class_property);
@@ -703,7 +708,7 @@ struct LocalizeWorker : Napi::AsyncWorker
             }
             else
             {
-                keep_every_worldview = true; // reassign to the same value as default for clarity
+                keep_all_non_hidden_worldviews = true; // reassign to the same value as default for clarity
                 incompatible_worldview_key = baton_data_->hidden_prefix + baton_data_->worldview_property;
                 compatible_worldview_key = baton_data_->worldview_property;
 
@@ -802,7 +807,7 @@ struct LocalizeWorker : Napi::AsyncWorker
                                     std::string property_value = static_cast<std::string>(property.value().string_value());
 
                                     // determine which worldviews to create a clone of the feature
-                                    if (keep_every_worldview)
+                                    if (keep_all_non_hidden_worldviews || is_international_tile_with_all_worldviews)
                                     {
                                         worldviews_to_create = {property_value};
                                     }

--- a/test/vtcomposite-localize-worldview.test.js
+++ b/test/vtcomposite-localize-worldview.test.js
@@ -1270,3 +1270,77 @@ test('[localize worldview] requesting localize langauge; feature not in the defa
     assert.end();
   });
 });
+
+test('[localize worldview] requesting worldviews=ALL returns no legacy worldview features', (assert) => {
+  const feature = mvtFixtures.create({
+    layers: [
+      {
+        version: 2,
+        name: 'admin',
+        features: [
+          {
+            id: 10,
+            tags: [0, 0],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          }
+        ],
+        keys: ['worldview'],
+        values: [
+          { string_value: 'CN' }
+        ],
+        extent: 4096
+      }
+    ]
+  }).buffer;
+
+  const params = {
+    buffer: feature,
+    worldviews: ['ALL']
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.deepEqual(tile.layers, {}, 'has no feature');
+    assert.end();
+  });
+});
+
+test('[localize worldview] requesting worldviews=ALL returns the comma separated list of worldviews', (assert) => {
+  const feature = mvtFixtures.create({
+    layers: [
+      {
+        version: 2,
+        name: 'admin',
+        features: [
+          {
+            id: 10,
+            tags: [0, 0],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          }
+        ],
+        keys: ['_mbx_worldview'],
+        values: [
+          { string_value: 'CN,JP,TR,US' }
+        ],
+        extent: 4096
+      }
+    ]
+  }).buffer;
+
+  const params = {
+    buffer: feature,
+    worldviews: ['ALL']
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, { worldview: 'CN,JP,TR,US' }, 'expected properties');
+    assert.end();
+  });
+});


### PR DESCRIPTION
Follow up to https://github.com/mapbox/vtcomposite/pull/136