### PR TITLE
Added the worldview keyword 'ALL' to return all the non-hidden worldviews for the given feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A filtering function for modifying a tile's features and properties to support l
   - `params.worldviews` **Array<Optional<String>>** array of ISO 3166-1 alpha-2 country codes used to filter out features of different worldviews.
     - Optional parameter.
     - For now, only the first item in the array will be processed; the rest are discarded (*TODO in the future*: expand support for more than one worldviews).
+    - When there is only the single value `ALL`, all the different worldviews are returned.
   - `params.worldview_property` **String** the name of the property that specifies in which worldview a feature belongs.
     - Default value: `worldview`.
     - The vector tile encoded property must contain a single ISO 3166-1 alpha-2 country code or a comma-separated string of country codes that define which worldviews the feature represents (for example: `JP`, `IN,RU,US`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/vtcomposite",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtcomposite",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Compositing operations on Vector Tiles (c++ bindings using N-API)",
   "url": "http://github.com/mapbox/vtcomposite",
   "main": "./lib/index.js",

--- a/src/vtcomposite.cpp
+++ b/src/vtcomposite.cpp
@@ -669,17 +669,18 @@ struct LocalizeWorker : Napi::AsyncWorker
     {
         try
         {
-            bool keep_every_worldview = true;
+            bool keep_all_non_hidden_worldviews = true;
             std::string incompatible_worldview_key;
             std::string compatible_worldview_key;
             std::vector<std::string> class_key_precedence;
             bool keep_all_non_hidden_languages = true;
-            bool is_international_tile_with_all_languages = false;
+            bool is_localized_tile_with_all_languages = false;
+            bool is_localized_tile_with_all_worldviews = false;
             std::vector<std::string> language_key_precedence;
 
             if (baton_data_->return_localized_tile)
             {
-                keep_every_worldview = false;
+                keep_all_non_hidden_worldviews = false;
                 incompatible_worldview_key = baton_data_->worldview_property;
                 compatible_worldview_key = baton_data_->hidden_prefix + baton_data_->worldview_property;
 
@@ -689,7 +690,7 @@ struct LocalizeWorker : Napi::AsyncWorker
                 keep_all_non_hidden_languages = false;
                 if (baton_data_->languages.size() == 1 && baton_data_->languages[0] == "all")
                 {
-                    is_international_tile_with_all_languages = true;
+                    is_localized_tile_with_all_languages = true;
                 }
                 else
                 {
@@ -700,10 +701,15 @@ struct LocalizeWorker : Napi::AsyncWorker
                     }
                     language_key_precedence.push_back(baton_data_->language_property);
                 }
+
+                if (baton_data_->worldviews.size() == 1 && baton_data_->worldviews[0] == "ALL")
+                {
+                    is_localized_tile_with_all_worldviews = true;
+                }
             }
             else
             {
-                keep_every_worldview = true; // reassign to the same value as default for clarity
+                keep_all_non_hidden_worldviews = true; // reassign to the same value as default for clarity
                 incompatible_worldview_key = baton_data_->hidden_prefix + baton_data_->worldview_property;
                 compatible_worldview_key = baton_data_->worldview_property;
 
@@ -802,7 +808,7 @@ struct LocalizeWorker : Napi::AsyncWorker
                                     std::string property_value = static_cast<std::string>(property.value().string_value());
 
                                     // determine which worldviews to create a clone of the feature
-                                    if (keep_every_worldview)
+                                    if (keep_all_non_hidden_worldviews || is_localized_tile_with_all_worldviews)
                                     {
                                         worldviews_to_create = {property_value};
                                     }
@@ -848,7 +854,7 @@ struct LocalizeWorker : Napi::AsyncWorker
                             utils::startswith(property_key, baton_data_->hidden_prefix + baton_data_->language_property))
                         {
 
-                            if (is_international_tile_with_all_languages)
+                            if (is_localized_tile_with_all_languages)
                             {
                                 std::string cleaned_property_key = remove_hidden_prefix(property_key, baton_data_->hidden_prefix);
 
@@ -974,7 +980,7 @@ struct LocalizeWorker : Napi::AsyncWorker
 
                     // Check the list of languages to be added
                     // Only add the ones that are different from original local language to the final properties
-                    if (is_international_tile_with_all_languages)
+                    if (is_localized_tile_with_all_languages)
                     {
                         for (const auto& language_property : language_properties_to_be_added_to_final_properties)
                         {

--- a/test/vtcomposite-localize-worldview.test.js
+++ b/test/vtcomposite-localize-worldview.test.js
@@ -1270,3 +1270,110 @@ test('[localize worldview] requesting localize langauge; feature not in the defa
     assert.end();
   });
 });
+
+test('[localize worldview] requesting worldviews=ALL returns no legacy worldview features', (assert) => {
+  const feature = mvtFixtures.create({
+    layers: [
+      {
+        version: 2,
+        name: 'admin',
+        features: [
+          {
+            id: 10,
+            tags: [
+              0, 0,
+              2, 2
+            ],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          },
+          {
+            id: 11,
+            tags: [
+              0, 1,
+              1, 1,
+              2, 2
+            ],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          }
+        ],
+        keys: ['worldview', '_mbx_worldview', 'class'],
+        values: [
+          { string_value: 'CN' },
+          { string_value: 'all' },
+          { string_value: 'foobar' }
+        ],
+        extent: 4096
+      }
+    ]
+  }).buffer;
+
+  const params = {
+    buffer: feature,
+    worldviews: ['ALL']
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 1, 'has one feature');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, { worldview: 'all', class: 'foobar' }, 'expected properties');
+    assert.end();
+  });
+});
+
+test('[localize worldview] requesting worldviews=ALL returns the comma separated list of worldviews', (assert) => {
+  const feature = mvtFixtures.create({
+    layers: [
+      {
+        version: 2,
+        name: 'admin',
+        features: [
+          {
+            id: 10,
+            tags: [
+              1, 0,
+              2, 2
+            ],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          },
+          {
+            id: 11,
+            tags: [
+              0, 1,
+              1, 1,
+              2, 2
+            ],
+            type: 1, // point
+            geometry: [9, 54, 38]
+          }
+        ],
+        keys: ['worldview', '_mbx_worldview', 'class'],
+        values: [
+          { string_value: 'CN,JP,TR,US' },
+          { string_value: 'all' },
+          { string_value: 'foobar' }
+        ],
+        extent: 4096
+      }
+    ]
+  }).buffer;
+
+  const params = {
+    buffer: feature,
+    worldviews: ['ALL']
+  };
+
+  localize(params, (err, vtBuffer) => {
+    assert.ifError(err);
+    const tile = vtinfo(vtBuffer);
+    assert.ok('admin' in tile.layers, 'has admin layer');
+    assert.equal(tile.layers.admin.length, 2, 'has two features');
+    assert.deepEqual(tile.layers.admin.feature(0).properties, { worldview: 'CN,JP,TR,US', class: 'foobar' }, 'First feature expected properties');
+    assert.deepEqual(tile.layers.admin.feature(1).properties, { worldview: 'all', class: 'foobar' }, 'Second feature expected properties');
+    assert.end();
+  });
+});


### PR DESCRIPTION
This adds support for the `ALL` keyword in the worldview options.